### PR TITLE
fix: libp2p configuration in browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@achingbrain/electron-fetch": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@achingbrain/electron-fetch/-/electron-fetch-1.7.2.tgz",
+      "integrity": "sha512-ShX5frO+2OddzRIlUb8D0Ao2eC3uZl910CYnRIPGLLM360vQceeOqpivwNdbry41Ph3MMtLR4RpzGdaADGG8Gg==",
+      "requires": {
+        "encoding": "^0.1.13"
+      }
+    },
     "@assemblyscript/loader": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
@@ -16,14 +24,6 @@
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
-      }
-    },
-    "@hapi/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
       }
     },
     "@hapi/ammo": {
@@ -43,9 +43,9 @@
       }
     },
     "@hapi/boom": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.1.tgz",
+      "integrity": "sha512-VNR8eDbBrOxBgbkddRYIe7+8DZ+vSbV6qlmaN2x7eWjsUjy2VmQgChkOKcVZIeupEZYj+I0dqNg430OhwzagjA==",
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -114,15 +114,10 @@
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
       "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
     },
-    "@hapi/formula": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
-    },
     "@hapi/hapi": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.1.tgz",
-      "integrity": "sha512-v8NapLf5vkKWIJoBCUBIOk6ZdH9vrxZco4GZbjdM3ROQBDl4eXwW3pySTBL7xWANYp3Nzdn+fiFWjDwdgsSoQg==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.3.tgz",
+      "integrity": "sha512-aqJVHVjoY3phiZsgsGjDRG15CoUNIs1azScqLZDOCZUSKYGTbzPi+K0QP+RUjUJ0m8L9dRuTZ27c8HKxG3wEhA==",
       "requires": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
@@ -155,9 +150,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
     "@hapi/inert": {
       "version": "6.0.3",
@@ -213,11 +208,6 @@
         "@hapi/hoek": "9.x.x",
         "@hapi/nigel": "4.x.x"
       }
-    },
-    "@hapi/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
     },
     "@hapi/podium": {
       "version": "4.1.1",
@@ -289,9 +279,9 @@
       }
     },
     "@hapi/validate": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.2.tgz",
-      "integrity": "sha512-ojg3iE/haKh8aCZFObkOzuJ1vQ8NP+EiuibliJKe01IMstBPXQc4Xl08+8zqAL+iZSZKp1TaWdwaNSzq8HIMKA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0"
@@ -306,9 +296,9 @@
       }
     },
     "@hapi/wreck": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
-      "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+      "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
@@ -321,25 +311,25 @@
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
+        "@nodelib/fs.stat": "2.0.4",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
       "requires": {
-        "@nodelib/fs.scandir": "2.1.3",
+        "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
     },
@@ -397,6 +387,24 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@sideway/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -418,19 +426,10 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^5.0.2"
-      }
-    },
     "@sinonjs/samsam": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
-      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
+      "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -468,62 +467,28 @@
         "@types/node": "*"
       }
     },
-    "@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
-    },
-    "@types/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
     },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
-    },
     "@types/node": {
-      "version": "14.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
-      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
     },
-    "@types/pbkdf2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+    "@types/readable-stream": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.9.tgz",
+      "integrity": "sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==",
       "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/secp256k1": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-      "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
-      "requires": {
-        "@types/node": "*"
+        "@types/node": "*",
+        "safe-buffer": "*"
       }
     },
     "@types/yauzl": {
@@ -576,9 +541,9 @@
       }
     },
     "abstract-logging": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.0.tgz",
-      "integrity": "sha512-/oA9z7JszpIioo6J6dB79LVUgJ3eD3cxkAmdCkvWWS+Y9tPtALs1rLqOekLUXUbYqM2fB9TTK0ibAyZJJOP/CA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -590,9 +555,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-node": {
@@ -618,11 +583,11 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "debug": "4"
       }
     },
     "aggregate-error": {
@@ -635,9 +600,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -699,20 +664,20 @@
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "requires": {
-        "@types/color-name": "^1.1.1",
         "color-convert": "^2.0.1"
       }
     },
     "any-signal": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-1.2.0.tgz",
-      "integrity": "sha512-Cl08k4xItix3jvu4cxO/dt2rQ6iUAjO66pTyRMub+WL1VXeAyZydCpD8GqWTPKfdL28U0R0UucmQVsUsBnvCmQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.1.tgz",
+      "integrity": "sha512-kjyMTtHQsB3yZAVDZlLVucPJnmnrXhamB/rm3Td3jse5Q+16FXXolP4elWU0yLFDyrxTkjjDXtIdjSPiEznf3w==",
       "requires": {
-        "abort-controller": "^3.0.0"
+        "abort-controller": "^3.0.0",
+        "native-abort-controller": "0.0.3"
       }
     },
     "aproba": {
@@ -824,13 +789,21 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
-    },
-    "array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-shuffle": {
       "version": "1.0.1",
@@ -919,20 +892,6 @@
         "lodash": "^4.17.14"
       }
     },
-    "async-iterator-to-pull-stream": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/async-iterator-to-pull-stream/-/async-iterator-to-pull-stream-1.3.0.tgz",
-      "integrity": "sha512-NjyhAEz/sx32olqgKIk/2xbWEM6o8qef1yetIgb0U/R3oBgndP1kE/0CslowH3jvnA94BO4I6OXpOkTKH7Z1AA==",
-      "requires": {
-        "get-iterator": "^1.0.2",
-        "pull-stream-to-async-iterator": "^1.0.1"
-      }
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -954,16 +913,16 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "backo2": {
@@ -990,14 +949,14 @@
       "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI="
     },
     "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64id": {
       "version": "2.0.0",
@@ -1007,8 +966,7 @@
     "basic-auth": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
-      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
-      "dev": true
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1027,23 +985,10 @@
         "loady": "~0.0.5"
       }
     },
-    "bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
-    "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
-      }
-    },
     "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -1057,67 +1002,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
-    "bip174": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
-      "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
-    },
-    "bip32": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.5.tgz",
-      "integrity": "sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==",
-      "requires": {
-        "@types/node": "10.12.18",
-        "bs58check": "^2.1.1",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "tiny-secp256k1": "^1.1.3",
-        "typeforce": "^1.11.5",
-        "wif": "^2.0.6"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.12.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
-        }
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "bitcoin-ops": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
-    },
-    "bitcoinjs-lib": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz",
-      "integrity": "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==",
-      "requires": {
-        "bech32": "^1.1.2",
-        "bip174": "^2.0.1",
-        "bip32": "^2.0.4",
-        "bip66": "^1.1.0",
-        "bitcoin-ops": "^1.4.0",
-        "bs58check": "^2.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.3",
-        "merkle-lib": "^2.0.10",
-        "pushdata-bitcoin": "^1.0.1",
-        "randombytes": "^2.0.1",
-        "tiny-secp256k1": "^1.1.1",
-        "typeforce": "^1.11.3",
-        "varuint-bitcoin": "^1.0.4",
-        "wif": "^2.0.1"
-      }
     },
     "bl": {
       "version": "4.0.3",
@@ -1140,11 +1024,11 @@
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "blob-to-it": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.2.tgz",
-      "integrity": "sha512-3/NRr0mUWQTkS71MYEC1teLbT5BTs7RZ6VMPXDV6qApjw3B4TAZspQuvDkYfHuD/XzL5p/RO91x5XRPeJvcCqg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.1.tgz",
+      "integrity": "sha512-papO4swPtR4MtNQ2foUkaS9e7HlD8XFQEBL3HZNhT4Qp6RQ/7t4C6bo4kRKtJV6A3AIgKR05Z9sbB+na6u+QYA==",
       "requires": {
-        "browser-readablestream-to-it": "^0.0.2"
+        "browser-readablestream-to-it": "^1.0.1"
       }
     },
     "bluebird": {
@@ -1194,19 +1078,6 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
@@ -1247,9 +1118,9 @@
       }
     },
     "browser-readablestream-to-it": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.2.tgz",
-      "integrity": "sha512-bbiTccngeAbPmpTUJcUyr6JhivADKV9xkNJVLdA91vjdzXyFBZ6fgrzElQsV3k1UNGQACRTl3p4y+cEGG9U48A=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.1.tgz",
+      "integrity": "sha512-vLeoyPpVY8IL5R4AEMI5nICVpuK1VBwBi6OUyuD1U9NUOL7UmAgP4agfbkkkZf+cBZaYtCYrgASd6YyVbIbsjA=="
     },
     "browser-resolve": {
       "version": "2.0.0",
@@ -1331,6 +1202,18 @@
             "ieee754": "^1.1.4"
           }
         },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
         "events": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
@@ -1387,6 +1270,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -1400,6 +1284,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
       "requires": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -1410,6 +1295,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -1418,18 +1304,28 @@
       }
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+      "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
+        "bn.js": "^5.0.0",
         "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
+          "dev": true
+        }
       }
     },
     "browserify-sign": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
       "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "dev": true,
       "requires": {
         "bn.js": "^5.1.1",
         "browserify-rsa": "^4.0.1",
@@ -1445,7 +1341,8 @@
         "bn.js": {
           "version": "5.1.3",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
+          "dev": true
         }
       }
     },
@@ -1458,31 +1355,13 @@
         "pako": "~1.0.5"
       }
     },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-crc32": {
@@ -1503,7 +1382,8 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
     },
     "bufio": {
       "version": "1.0.7",
@@ -1540,6 +1420,14 @@
         "responselike": "^1.0.2"
       },
       "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -1553,10 +1441,14 @@
       "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
     },
-    "callsite": {
+    "call-bind": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -1569,11 +1461,11 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "cbor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.1.0.tgz",
-      "integrity": "sha512-qzEc7kUShdMbWTaUH7X+aHW8owvBU3FS0dfYR1lGYpoZr0mGJhhojLlZJH653x/DfeMZ56h315FRNBUIG1R7qg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
+      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
       "requires": {
-        "bignumber.js": "^9.0.0",
+        "bignumber.js": "^9.0.1",
         "nofilter": "^1.0.4"
       }
     },
@@ -1631,21 +1523,6 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "check-error": {
@@ -1659,16 +1536,17 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chromedriver": {
-      "version": "83.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-83.0.1.tgz",
-      "integrity": "sha512-51/YsLIMRF+L0ooMlM4aZjyoOpDs0gDXGlT6+/CwWEnvK53PUyef9FkotKbzknCaUeL/qUw3ic3IMmsNc+SUxg==",
+      "version": "87.0.5",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-87.0.5.tgz",
+      "integrity": "sha512-bWAKdZANrt3LXMUOKFP+DgW7DjVKfihCbjej6URkUcKsvbQBDYpf5YY5d/dXE3SOSzIFZ7fmLxogusxpsupCJg==",
       "requires": {
         "@testim/chrome-version": "^1.0.7",
-        "axios": "^0.19.2",
-        "del": "^5.1.0",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^2.2.4",
+        "axios": "^0.21.0",
+        "del": "^6.0.0",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
         "mkdirp": "^1.0.4",
+        "proxy-from-env": "^1.1.0",
         "tcp-port-used": "^1.0.1"
       }
     },
@@ -1689,16 +1567,35 @@
         "split2": "^3.1.1",
         "uint8arrays": "^1.1.0",
         "yargs": "^15.0.2"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        }
       }
     },
     "cids": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.1.tgz",
-      "integrity": "sha512-A5DvnNMr7ABdP3IWFPEdbpued8Sw2cHu6n4+Hke9MpzEqhQH74Pm6Zk2TB59aNHIuue1Oh/jZi/t0wgISWgOow==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.4.tgz",
+      "integrity": "sha512-mo0IWZKcaQZsret8cP39MzDnPVT9NhhQEVaIKwWnBFaLtj2slTFckYMnbk15ptewNkb22qRBLfuBK+qiWYW/Mg==",
       "requires": {
-        "class-is": "^1.1.0",
         "multibase": "^3.0.1",
-        "multicodec": "^2.0.1",
+        "multicodec": "^2.1.0",
         "multihashes": "^3.0.1",
         "uint8arrays": "^1.1.0"
       }
@@ -1707,6 +1604,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -1736,9 +1634,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
-      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ=="
     },
     "cliui": {
       "version": "6.0.0",
@@ -1787,9 +1685,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combine-source-map": {
       "version": "0.8.0",
@@ -1830,9 +1728,9 @@
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "component-inherit": {
       "version": "0.0.3",
@@ -1845,53 +1743,14 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "configstore": {
@@ -1931,9 +1790,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1949,6 +1808,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
       "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
@@ -1958,6 +1818,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -1970,6 +1831,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -1993,6 +1855,7 @@
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -2013,9 +1876,9 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
     "dag-cbor-links": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-2.0.0.tgz",
-      "integrity": "sha512-ra3oaFkrl57zcZf0l5F/L9l8QTdqdO9XZLpbXsNT0EX4NPL34RDN4r6Uuk6LI1WQLFfM0prSCbAEdOWxzUJo3A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-2.0.2.tgz",
+      "integrity": "sha512-PS5skw2eGKVZ1VVu9wquoIoefgMvKhl9/OItzf+7UMot0Nnd3oe/Ai5AP48GvEkAi6GkmglhWwuoKF23hTHJqQ==",
       "requires": {
         "cids": "^1.0.0",
         "ipld-dag-cbor": "^0.17.0"
@@ -2041,46 +1904,62 @@
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
     },
     "datastore-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-2.0.0.tgz",
-      "integrity": "sha512-E6SS3GEZNMCRZScWO98qQ14MIb7+3MLsJtcgla/ULCjfnhThsUE21HN+wT0+QLoYrKR54puWy/3XKp5N+5+zyA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-2.0.1.tgz",
+      "integrity": "sha512-er9DVcug5aM/qJFaG7pFmYah1f5XvUsHZ5nf9+MOFUKB3pCLlQIrClSu+Nl9hfROS9yiou6i5dFZu9PL9IQ+gQ==",
       "requires": {
         "debug": "^4.1.1",
         "interface-datastore": "^2.0.0",
-        "ipfs-utils": "^2.3.1"
+        "ipfs-utils": "^4.0.1"
       },
       "dependencies": {
-        "ipfs-utils": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
           "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "ipfs-utils": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-4.0.1.tgz",
+          "integrity": "sha512-6mg+S1sbjj+Ff+uoHOhVeC4myfV2tb2sHcdYwfpJ4ZcBo9WfdxSMnWFLiC5bIqByyJuN/g5aWgz3ozjKDzND1Q==",
+          "requires": {
+            "@achingbrain/electron-fetch": "^1.7.2",
             "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
+            "any-signal": "^2.1.0",
+            "buffer": "^6.0.1",
             "err-code": "^2.0.0",
             "fs-extra": "^9.0.1",
             "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "it-to-stream": "^0.1.2",
+            "iso-url": "^1.0.0",
+            "it-glob": "0.0.10",
             "merge-options": "^2.0.0",
             "nanoid": "^3.1.3",
+            "native-abort-controller": "0.0.3",
+            "native-fetch": "^2.0.0",
             "node-fetch": "^2.6.0",
             "stream-to-it": "^0.2.0"
           }
+        },
+        "iso-url": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.0.0.tgz",
+          "integrity": "sha512-n/MsHgKOoHcFrhsxfbM3aaSdUujoFrrZ3537p3RW80AL7axL36acCseoMwIW4tNOl0n0SnkzNyVh4bREwmHoPQ=="
         }
       }
     },
     "datastore-fs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.1.tgz",
-      "integrity": "sha512-W0qOEJDHVmzSfCXMBcgnHI7n0SROQ7vpD24v9AicVWE/DPju4CUWl/1NHSQO3RR3ooaFdG31c1J2OjDKJO6+Fg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.2.tgz",
+      "integrity": "sha512-OA1jKopZy5fMMIJNASRRJoj36AgD/v1TIp843o+3B7x4ffSiUArHUzbLRIBchD6VGLklz/3i4mtZeIaALsh/ZQ==",
       "requires": {
         "datastore-core": "^2.0.0",
         "fast-write-atomic": "^0.2.0",
         "interface-datastore": "^2.0.0",
-        "it-glob": "0.0.8",
+        "it-glob": "0.0.10",
         "mkdirp": "^1.0.4"
       }
     },
@@ -2095,14 +1974,25 @@
       }
     },
     "datastore-pubsub": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.4.1.tgz",
-      "integrity": "sha512-OVKIlSqILBSFApJ5FPmiWaSA71l53sX52sV0JgyGBaghzqbFTTB1HQikB8npSyGMEJfmpCVhKue9rkTHF+WoXg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.4.2.tgz",
+      "integrity": "sha512-ig7p3pYxs+LRZ8EnU3LGMC5z2fV5f3ZsFAszJjdiHaayBixXpQg7J2Kcv28apr4eJg+Zs0kClPdlM3LRqvwaBg==",
       "requires": {
-        "debug": "^4.1.1",
+        "debug": "^4.2.0",
         "err-code": "^2.0.3",
         "interface-datastore": "^2.0.0",
-        "uint8arrays": "^1.1.0"
+        "uint8arrays": "^2.0.5"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.0.5.tgz",
+          "integrity": "sha512-1HSktgwqtYIwVn1mg3GcnqKhHH9oC4kVgdD/43cxMWwhP8rihKcFPmToDzS1XtbvVvlR8XxTk/DUBf0C83qNIg==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        }
       }
     },
     "dateformat": {
@@ -2111,9 +2001,9 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -2191,13 +2081,6 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
         "object-keys": "^1.0.12"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-        }
       }
     },
     "defined": {
@@ -2224,28 +2107,20 @@
       }
     },
     "del": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
-      "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
       "requires": {
-        "globby": "^10.0.1",
-        "graceful-fs": "^4.2.2",
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
         "is-glob": "^4.0.1",
         "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.1",
-        "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -2277,9 +2152,9 @@
       "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -2302,6 +2177,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
       "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -2342,6 +2218,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -2365,6 +2242,16 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "dns-over-http-resolver": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.0.tgz",
+      "integrity": "sha512-LJ1sEbQgwY+qmL6z3kNIKi0vHA9nSUdZb8vf3G6z43ZVIF6WhhNHXztLMOOvaMIvtCsCZBjAie11MtUD3+H0YA==",
+      "requires": {
+        "debug": "^4.2.0",
+        "native-fetch": "^2.0.1",
+        "receptacle": "^1.3.2"
+      }
     },
     "dns-packet": {
       "version": "4.2.0",
@@ -2492,6 +2379,14 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
+    "electron-fetch": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.2.tgz",
+      "integrity": "sha512-J7D136rhxIhPwYJsnHPpKgbyd4NUCGnKM1CuXLhmVWZdc8f6+LBiJqUOTngtSacj+xvGWgaDWOAuCXnhqiMTCw==",
+      "requires": {
+        "encoding": "^0.1.13"
+      }
+    },
     "elliptic": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
@@ -2510,6 +2405,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "encoding-down": {
       "version": "6.3.0",
@@ -2545,16 +2448,16 @@
       }
     },
     "engine.io": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.2.tgz",
-      "integrity": "sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.5.0.tgz",
+      "integrity": "sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==",
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
-        "cookie": "0.3.1",
+        "cookie": "~0.4.1",
         "debug": "~4.1.0",
         "engine.io-parser": "~2.2.0",
-        "ws": "^7.1.2"
+        "ws": "~7.4.2"
       },
       "dependencies": {
         "debug": {
@@ -2568,54 +2471,46 @@
       }
     },
     "engine.io-client": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
-      "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
+      "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
       "requires": {
         "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
-        "debug": "~4.1.0",
+        "debug": "~3.1.0",
         "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "~6.1.0",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~7.4.2",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-        },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.0.0"
           }
         },
-        "ws": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "engine.io-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
+        "base64-arraybuffer": "0.1.4",
         "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
@@ -2631,35 +2526,42 @@
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "requires": {
         "prr": "~1.0.1"
       }
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       },
       "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
         }
       }
     },
@@ -2685,6 +2587,11 @@
       "requires": {
         "es6-promise": "^4.0.3"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -2723,236 +2630,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
-    "ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "requires": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "ethereumjs-account": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
-      "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
-      "requires": {
-        "ethereumjs-util": "^6.0.0",
-        "rlp": "^2.2.1",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "ethereumjs-block": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-      "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-      "requires": {
-        "async": "^2.0.1",
-        "ethereumjs-common": "^1.5.0",
-        "ethereumjs-tx": "^2.1.1",
-        "ethereumjs-util": "^5.0.0",
-        "merkle-patricia-tree": "^2.1.2"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "~2.6.0"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "~0.1.1"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "^2.0.1",
-            "level-errors": "^1.0.3",
-            "readable-stream": "^1.0.33",
-            "xtend": "^4.0.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-              }
-            }
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "~1.2.1",
-            "level-codec": "~7.0.0",
-            "level-errors": "~1.0.3",
-            "level-iterator-stream": "~1.3.0",
-            "prr": "~1.0.1",
-            "semver": "~5.4.1",
-            "xtend": "~4.0.0"
-          }
-        },
-        "merkle-patricia-tree": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-          "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
-          "requires": {
-            "async": "^1.4.2",
-            "ethereumjs-util": "^5.0.0",
-            "level-ws": "0.0.0",
-            "levelup": "^1.2.1",
-            "memdown": "^1.0.0",
-            "readable-stream": "^2.0.0",
-            "rlp": "^2.0.0",
-            "semaphore": ">=1.0.1"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
-    "ethereumjs-common": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA=="
-    },
-    "ethereumjs-tx": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-      "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-      "requires": {
-        "ethereumjs-common": "^1.5.0",
-        "ethereumjs-util": "^6.0.0"
-      }
-    },
-    "ethereumjs-util": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-      "requires": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
-      }
-    },
-    "ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      }
-    },
     "event-iterator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
@@ -2977,15 +2654,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "requires": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -2996,6 +2674,21 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2",
         "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+        }
       }
     },
     "explain-error": {
@@ -3017,6 +2710,16 @@
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
       }
     },
     "extsprintf": {
@@ -3058,9 +2761,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-redact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
-      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
+      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
@@ -3073,9 +2776,9 @@
       "integrity": "sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw=="
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
+      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -3089,11 +2792,11 @@
       }
     },
     "file-type": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.7.1.tgz",
-      "integrity": "sha512-sXAMgFk67fQLcetXustxfKX+PZgHIUFn96Xld9uH8aXPdX3xOp0/jg9OdouVTvQrf7mrn+wAa4jN/y9fUOOiRA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.1.0.tgz",
+      "integrity": "sha512-G4Klqf6tuprtG0pC4r9kni4Wv8XhAAsfHphVqsQGA+YiOlPAO40BZduDqKfv0RFsu9q9ZbFObWfwszY/NqhEZw==",
       "requires": {
-        "readable-web-to-node-stream": "^2.0.0",
+        "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.0.3",
         "token-types": "^2.0.0",
         "typedarray-to-buffer": "^3.1.5"
@@ -3127,9 +2830,9 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
       "requires": {
         "is-buffer": "~2.0.3"
       }
@@ -3145,27 +2848,9 @@
       "integrity": "sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU="
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -3238,11 +2923,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-    },
     "gar": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
@@ -3308,26 +2988,22 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -3336,14 +3012,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -3352,38 +3026,32 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+          "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ms": "^2.1.1"
@@ -3391,26 +3059,22 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+          "bundled": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -3418,14 +3082,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -3440,8 +3102,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3454,14 +3115,12 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -3469,8 +3128,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -3478,8 +3136,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -3488,20 +3145,17 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -3509,14 +3163,12 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -3524,14 +3176,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -3540,8 +3190,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -3549,8 +3198,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minimist": "0.0.8"
@@ -3558,14 +3206,12 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "bundled": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.1.tgz",
-          "integrity": "sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "debug": "^4.1.0",
@@ -3575,8 +3221,7 @@
         },
         "node-pre-gyp": {
           "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
-          "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -3593,8 +3238,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -3603,14 +3247,12 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+          "bundled": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -3619,8 +3261,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -3631,20 +3272,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "wrappy": "1"
@@ -3652,20 +3290,17 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -3674,20 +3309,17 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -3698,16 +3330,14 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3721,8 +3351,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "glob": "^7.1.3"
@@ -3730,44 +3359,37 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "bundled": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "bundled": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -3777,8 +3399,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -3786,8 +3407,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3795,14 +3415,12 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -3816,14 +3434,12 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
@@ -3831,14 +3447,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "bundled": true,
           "optional": true
         }
       }
@@ -3850,9 +3464,9 @@
       "dev": true
     },
     "get-browser-rtc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.0.2.tgz",
-      "integrity": "sha1-u81AyEUaftTvXDc7gWmkCd0dEdk="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -3873,18 +3487,25 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
+    "get-intrinsic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-iterator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
       "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "requires": {
-        "pump": "^3.0.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg=="
     },
     "get-uri": {
       "version": "2.0.4",
@@ -3976,27 +3597,20 @@
       }
     },
     "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "requires": {
         "min-document": "^2.19.0",
-        "process": "~0.5.1"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-        }
+        "process": "^0.11.10"
       }
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "1.3.7"
       }
     },
     "globalthis": {
@@ -4008,17 +3622,15 @@
       }
     },
     "globby": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
+      "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
       "requires": {
-        "@types/glob": "^7.1.1",
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
         "slash": "^3.0.0"
       }
     },
@@ -4127,9 +3739,9 @@
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -4150,6 +3762,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -4232,6 +3845,14 @@
         "debug": "3.1.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -4251,7 +3872,6 @@
       "version": "0.12.3",
       "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.3.tgz",
       "integrity": "sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==",
-      "dev": true,
       "requires": {
         "basic-auth": "^1.0.3",
         "colors": "^1.4.0",
@@ -4263,35 +3883,6 @@
         "portfinder": "^1.0.25",
         "secure-compare": "3.0.1",
         "union": "~0.5.0"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "dev": true
-        },
-        "opener": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-          "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.9.4",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-          "dev": true
-        },
-        "union": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
-          "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
-          "dev": true,
-          "requires": {
-            "qs": "^6.4.0"
-          }
-        }
       }
     },
     "http-signature": {
@@ -4311,41 +3902,31 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.1.8",
@@ -4400,9 +3981,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
     },
     "inline-source-map": {
       "version": "0.6.2",
@@ -4422,9 +4003,9 @@
       }
     },
     "insert-module-globals": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
-      "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+      "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.3",
@@ -4439,214 +4020,111 @@
         "xtend": "^4.0.0"
       },
       "dependencies": {
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
-    "interface-connection": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.3.tgz",
-      "integrity": "sha512-OV9Rj7AhUlssWJTO6nOazJdPFGqWDOVZ3j5aM+i0RPKyTzR87vJ949VqhMyKkCIR0GBAaNqfB7F4YA70a/QWiw==",
-      "requires": {
-        "pull-defer": "~0.2.3"
-      }
-    },
     "interface-datastore": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.0.tgz",
-      "integrity": "sha512-wOImix5uVEZWo+8zPSRMJ9nHbszZi3PhZ14KHLN7oRQjaYQtjtOpYj6n5EXTjDAfIQI8KN9vntHXxyAw1lcRIA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.1.tgz",
+      "integrity": "sha512-a4xHvVE8JCG8UItP0CCq+UJyBHZxhMp3esuFNjb3U9rP+tzKiG0HZXz8gIIwic6VbuE0Gui2whbJyJOFpMxhLg==",
       "requires": {
         "class-is": "^1.1.0",
         "err-code": "^2.0.1",
-        "ipfs-utils": "^2.3.1",
+        "ipfs-utils": "^4.0.1",
         "iso-random-stream": "^1.1.1",
         "it-all": "^1.0.2",
         "it-drain": "^1.0.1",
         "nanoid": "^3.0.2"
       },
       "dependencies": {
-        "ipfs-utils": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
           "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "ipfs-utils": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-4.0.1.tgz",
+          "integrity": "sha512-6mg+S1sbjj+Ff+uoHOhVeC4myfV2tb2sHcdYwfpJ4ZcBo9WfdxSMnWFLiC5bIqByyJuN/g5aWgz3ozjKDzND1Q==",
+          "requires": {
+            "@achingbrain/electron-fetch": "^1.7.2",
             "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
+            "any-signal": "^2.1.0",
+            "buffer": "^6.0.1",
             "err-code": "^2.0.0",
             "fs-extra": "^9.0.1",
             "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "it-to-stream": "^0.1.2",
+            "iso-url": "^1.0.0",
+            "it-glob": "0.0.10",
             "merge-options": "^2.0.0",
             "nanoid": "^3.1.3",
+            "native-abort-controller": "0.0.3",
+            "native-fetch": "^2.0.0",
             "node-fetch": "^2.6.0",
             "stream-to-it": "^0.2.0"
           }
-        }
-      }
-    },
-    "interface-transport": {
-      "version": "github:libp2p/interface-transport#1dcdef69055c78a9fff96c6f24feb34ced0e5e9d",
-      "from": "github:libp2p/interface-transport#chore/skip-abort-while-reading-for-webrtc",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "async-iterator-to-pull-stream": "^1.3.0",
-        "chai": "^4.2.0",
-        "dirty-chai": "^2.0.1",
-        "interface-connection": "~0.3.3",
-        "it-goodbye": "^2.0.0",
-        "it-pipe": "^1.0.0",
-        "multiaddr": "^7.0.0",
-        "pull-stream": "^3.6.9",
-        "sinon": "^7.4.2",
-        "streaming-iterables": "^4.1.0"
-      },
-      "dependencies": {
-        "@sinonjs/formatio": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-          "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
-          "requires": {
-            "@sinonjs/commons": "^1",
-            "@sinonjs/samsam": "^3.1.0"
-          }
         },
-        "@sinonjs/samsam": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-          "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
-          "requires": {
-            "@sinonjs/commons": "^1.3.0",
-            "array-from": "^2.1.1",
-            "lodash": "^4.17.15"
-          }
-        },
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-        },
-        "multiaddr": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "cids": "~0.8.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        },
-        "nise": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
-          "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
-          "requires": {
-            "@sinonjs/formatio": "^3.2.1",
-            "@sinonjs/text-encoding": "^0.7.1",
-            "just-extend": "^4.0.2",
-            "lolex": "^5.0.1",
-            "path-to-regexp": "^1.7.0"
-          },
-          "dependencies": {
-            "lolex": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-              "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-              "requires": {
-                "@sinonjs/commons": "^1.7.0"
-              }
-            }
-          }
-        },
-        "sinon": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
-          "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
-          "requires": {
-            "@sinonjs/commons": "^1.4.0",
-            "@sinonjs/formatio": "^3.2.1",
-            "@sinonjs/samsam": "^3.3.3",
-            "diff": "^3.5.0",
-            "lolex": "^4.2.0",
-            "nise": "^1.5.2",
-            "supports-color": "^5.5.0"
-          }
-        },
-        "streaming-iterables": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
-          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA=="
+        "iso-url": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.0.0.tgz",
+          "integrity": "sha512-n/MsHgKOoHcFrhsxfbM3aaSdUujoFrrZ3537p3RW80AL7axL36acCseoMwIW4tNOl0n0SnkzNyVh4bREwmHoPQ=="
         }
       }
     },
@@ -4670,142 +4148,38 @@
       }
     },
     "ip-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
+      "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A=="
     },
     "ipfs": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.50.2.tgz",
-      "integrity": "sha512-mgXab5fxyUwQpy/NNfOCplql+Em2DhyWLYjTOgIaaCrWTssejeZyRETBYZazAwIk1xNsIDX3IgOfXlzWw850bw==",
+      "version": "0.52.3",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.52.3.tgz",
+      "integrity": "sha512-zCd2Ziq1GYDJizXdoAj5nof325i3mx2kzOhG6E+xdEK6FcK6kQwKendaBlQHwTbzHLqLI7ITxsepQzFWNopI2g==",
       "requires": {
-        "@hapi/ammo": "^5.0.1",
-        "@hapi/boom": "^9.1.0",
-        "@hapi/content": "^5.0.2",
-        "@hapi/hapi": "^20.0.0",
-        "abort-controller": "^3.0.0",
-        "any-signal": "^1.1.0",
-        "array-shuffle": "^1.0.1",
-        "bignumber.js": "^9.0.0",
-        "bl": "^4.0.2",
-        "byteman": "^1.3.5",
-        "cbor": "^5.0.1",
-        "cid-tool": "^1.0.0",
-        "cids": "^1.0.0",
-        "class-is": "^1.1.0",
-        "dag-cbor-links": "^2.0.0",
-        "datastore-core": "^2.0.0",
-        "datastore-pubsub": "^0.4.0",
-        "debug": "^4.1.0",
-        "dlv": "^1.1.3",
-        "err-code": "^2.0.0",
-        "execa": "^4.0.0",
-        "file-type": "^14.1.4",
-        "fnv1a": "^1.0.1",
-        "get-folder-size": "^2.0.0",
-        "hamt-sharding": "^1.0.0",
-        "hapi-pino": "^8.2.0",
-        "hashlru": "^2.3.0",
-        "interface-datastore": "^2.0.0",
-        "ipfs-bitswap": "^3.0.0",
-        "ipfs-block-service": "^0.18.0",
-        "ipfs-core-utils": "^0.4.0",
-        "ipfs-http-client": "^47.0.1",
-        "ipfs-http-response": "^0.6.0",
-        "ipfs-repo": "^6.0.3",
-        "ipfs-unixfs": "^2.0.2",
-        "ipfs-unixfs-exporter": "^3.0.2",
-        "ipfs-unixfs-importer": "^3.0.2",
-        "ipfs-utils": "^3.0.0",
-        "ipld": "^0.27.1",
-        "ipld-bitcoin": "^0.4.0",
-        "ipld-block": "^0.10.0",
-        "ipld-dag-cbor": "^0.17.0",
-        "ipld-dag-pb": "^0.20.0",
-        "ipld-ethereum": "^5.0.1",
-        "ipld-git": "^0.6.1",
-        "ipld-raw": "^6.0.0",
-        "ipld-zcash": "^0.5.0",
-        "ipns": "^0.8.0",
-        "is-domain-name": "^1.0.1",
-        "is-ipfs": "^2.0.0",
-        "iso-url": "^0.4.7",
-        "it-all": "^1.0.1",
-        "it-concat": "^1.0.0",
-        "it-drain": "^1.0.1",
-        "it-first": "^1.0.1",
-        "it-glob": "0.0.8",
-        "it-last": "^1.0.2",
-        "it-map": "^1.0.2",
-        "it-multipart": "^1.0.1",
-        "it-pipe": "^1.1.0",
-        "it-tar": "^1.2.2",
-        "it-to-stream": "^0.1.1",
-        "iterable-ndjson": "^1.1.0",
-        "joi": "^17.2.1",
-        "jsondiffpatch": "^0.4.1",
-        "just-safe-set": "^2.1.0",
-        "libp2p": "^0.29.0",
-        "libp2p-bootstrap": "^0.12.0",
-        "libp2p-crypto": "^0.18.0",
-        "libp2p-delegated-content-routing": "^0.7.0",
-        "libp2p-delegated-peer-routing": "^0.7.0",
-        "libp2p-floodsub": "^0.23.0",
-        "libp2p-gossipsub": "^0.6.0",
-        "libp2p-kad-dht": "^0.20.0",
-        "libp2p-mdns": "^0.15.0",
-        "libp2p-mplex": "^0.10.0",
-        "libp2p-noise": "^2.0.0",
-        "libp2p-record": "^0.9.0",
-        "libp2p-secio": "^0.13.0",
-        "libp2p-tcp": "^0.15.0",
-        "libp2p-webrtc-star": "^0.20.0",
-        "libp2p-websockets": "^0.14.0",
-        "mafmt": "^8.0.0",
-        "merge-options": "^2.0.0",
-        "mortice": "^2.0.0",
-        "multiaddr": "^8.0.0",
-        "multiaddr-to-uri": "^6.0.0",
-        "multibase": "^3.0.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.1",
-        "p-defer": "^3.0.0",
-        "p-queue": "^6.1.0",
-        "parse-duration": "^0.4.4",
-        "peer-id": "^0.14.0",
-        "pretty-bytes": "^5.3.0",
-        "progress": "^2.0.1",
-        "prom-client": "^12.0.0",
-        "prometheus-gc-stats": "^0.6.0",
-        "protons": "^2.0.0",
+        "debug": "^4.1.1",
+        "ipfs-cli": "^0.2.3",
+        "ipfs-core": "^0.3.1",
+        "ipfs-repo": "^7.0.0",
         "semver": "^7.3.2",
-        "stream-to-it": "^0.2.1",
-        "streaming-iterables": "^5.0.0",
-        "temp": "^0.9.0",
-        "timeout-abort-controller": "^1.1.0",
-        "uint8arrays": "^1.1.0",
-        "update-notifier": "^4.0.0",
-        "uri-to-multiaddr": "^4.0.0",
-        "varint": "^5.0.0",
-        "yargs": "^15.1.0",
-        "yargs-promise": "^1.1.0"
+        "update-notifier": "^5.0.0"
       }
     },
     "ipfs-bitswap": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-3.0.0.tgz",
-      "integrity": "sha512-9rX9vMUEegk61O4OoUWBUcU/WLLwALhyzHQdJzqW1DCn+nNnZVbRrzIWY1v5PnlywMtcUvd/ennpegVKCPuiUA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-4.0.0.tgz",
+      "integrity": "sha512-KQjRX6h2bU0DgHxCFTAgn0JJPs3sF2eTwn5kD54M1A+KeKmHG21EVyXo/ZSO2iDWgERmL66WnA+jX7xM1p2k+Q==",
       "requires": {
         "abort-controller": "^3.0.0",
-        "any-signal": "^1.1.0",
+        "any-signal": "^2.1.1",
         "bignumber.js": "^9.0.0",
         "cids": "^1.0.0",
         "debug": "^4.1.0",
-        "ipld-block": "^0.10.0",
+        "ipld-block": "^0.11.0",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.1.0",
         "just-debounce-it": "^1.1.0",
-        "libp2p-interfaces": "^0.4.1",
+        "libp2p-interfaces": "^0.7.1",
         "moving-average": "^1.0.0",
         "multicodec": "^2.0.0",
         "multihashing-async": "^2.0.1",
@@ -4824,26 +4198,558 @@
         "streaming-iterables": "^5.0.2"
       }
     },
-    "ipfs-core-utils": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.4.0.tgz",
-      "integrity": "sha512-IBPFvYjWPfVFpCeYUL/0gCUOabdBhh7aO5i4tU//UlF2gVCXPH4PRYlbBH9WM83zE2+o4vDi+dBXsdAI6nLPAg==",
+    "ipfs-cli": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ipfs-cli/-/ipfs-cli-0.2.3.tgz",
+      "integrity": "sha512-3DGUh/V9INVPG5dv0bT1DQpjVM5diKEVrVYSMtk/h5enVPbNHTZ+Dz4zOwjRsob5QQNkdVQWdHnhCcRHNyWFCA==",
       "requires": {
-        "blob-to-it": "0.0.2",
-        "browser-readablestream-to-it": "0.0.2",
+        "bignumber.js": "^9.0.0",
+        "byteman": "^1.3.5",
+        "cid-tool": "^1.0.0",
         "cids": "^1.0.0",
-        "err-code": "^2.0.0",
-        "ipfs-utils": "^3.0.0",
-        "it-all": "^1.0.1",
-        "it-map": "^1.0.2",
-        "it-peekable": "0.0.1",
+        "debug": "^4.1.1",
+        "err-code": "^2.0.3",
+        "execa": "^5.0.0",
+        "get-folder-size": "^2.0.1",
+        "ipfs-core": "^0.3.1",
+        "ipfs-core-utils": "^0.5.4",
+        "ipfs-daemon": "^0.3.2",
+        "ipfs-http-client": "^48.1.3",
+        "ipfs-repo": "^7.0.0",
+        "ipfs-utils": "^5.0.0",
+        "ipld-dag-cbor": "^0.17.0",
+        "ipld-dag-pb": "^0.20.0",
+        "it-all": "^1.0.4",
+        "it-concat": "^1.0.1",
+        "it-first": "^1.0.4",
+        "it-glob": "0.0.10",
+        "it-pipe": "^1.1.0",
+        "jsondiffpatch": "^0.4.1",
+        "libp2p-crypto": "^0.18.0",
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
+        "multibase": "^3.0.0",
+        "multihashing-async": "^2.0.1",
+        "parse-duration": "^0.4.4",
+        "peer-id": "^0.14.1",
+        "pretty-bytes": "^5.4.1",
+        "progress": "^2.0.3",
+        "stream-to-it": "^0.2.2",
+        "streaming-iterables": "^5.0.2",
+        "uint8arrays": "^1.1.0",
+        "yargs": "^16.0.3"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+          "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "ipfs-http-client": {
+          "version": "48.1.3",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-48.1.3.tgz",
+          "integrity": "sha512-+JV4cdMaTvYN3vd4r6+mcVxV3LkJXzc4kn2ToVbObpVpdqmG34ePf1KlvFF8A9gjcel84WpiP5xCEV/IrisPBA==",
+          "requires": {
+            "any-signal": "^2.0.0",
+            "bignumber.js": "^9.0.0",
+            "cids": "^1.0.0",
+            "debug": "^4.1.1",
+            "form-data": "^3.0.0",
+            "ipfs-core-utils": "^0.5.4",
+            "ipfs-utils": "^5.0.0",
+            "ipld-block": "^0.11.0",
+            "ipld-dag-cbor": "^0.17.0",
+            "ipld-dag-pb": "^0.20.0",
+            "ipld-raw": "^6.0.0",
+            "it-last": "^1.0.4",
+            "it-map": "^1.0.4",
+            "it-tar": "^1.2.2",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.1",
+            "multihashes": "^3.0.1",
+            "nanoid": "^3.1.12",
+            "native-abort-controller": "~0.0.3",
+            "parse-duration": "^0.4.4",
+            "stream-to-it": "^0.2.2",
+            "uint8arrays": "^1.1.0"
+          }
+        }
+      }
+    },
+    "ipfs-core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ipfs-core/-/ipfs-core-0.3.1.tgz",
+      "integrity": "sha512-d94i8Bvhm+0a38rZG2q7EcQXcVT4cTkjCZAu7ZZ4HOWyB0EevqrxH6D7VK3zv6fe+iOC6iv4qrB+Wtt1pE6NVw==",
+      "requires": {
+        "array-shuffle": "^1.0.1",
+        "bignumber.js": "^9.0.0",
+        "cbor": "^5.1.0",
+        "cids": "^1.0.0",
+        "class-is": "^1.1.0",
+        "dag-cbor-links": "^2.0.0",
+        "datastore-core": "^2.0.0",
+        "datastore-pubsub": "^0.4.1",
+        "debug": "^4.1.1",
+        "dlv": "^1.1.3",
+        "err-code": "^2.0.3",
+        "hamt-sharding": "^1.0.0",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^2.0.0",
+        "ipfs-bitswap": "^4.0.0",
+        "ipfs-block-service": "^0.18.0",
+        "ipfs-core-utils": "^0.5.4",
+        "ipfs-repo": "^7.0.0",
+        "ipfs-unixfs": "^2.0.3",
+        "ipfs-unixfs-exporter": "^3.0.4",
+        "ipfs-unixfs-importer": "^5.0.0",
+        "ipfs-utils": "^5.0.0",
+        "ipld": "^0.28.0",
+        "ipld-block": "^0.11.0",
+        "ipld-dag-cbor": "^0.17.0",
+        "ipld-dag-pb": "^0.20.0",
+        "ipld-raw": "^6.0.0",
+        "ipns": "^0.8.0",
+        "is-domain-name": "^1.0.1",
+        "is-ipfs": "^2.0.0",
+        "it-all": "^1.0.4",
+        "it-first": "^1.0.4",
+        "it-last": "^1.0.4",
+        "it-pipe": "^1.1.0",
+        "libp2p": "^0.29.3",
+        "libp2p-bootstrap": "^0.12.1",
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-floodsub": "^0.23.1",
+        "libp2p-gossipsub": "^0.6.1",
+        "libp2p-kad-dht": "^0.20.1",
+        "libp2p-mdns": "^0.15.0",
+        "libp2p-mplex": "^0.10.0",
+        "libp2p-noise": "^2.0.1",
+        "libp2p-record": "^0.9.0",
+        "libp2p-tcp": "^0.15.1",
+        "libp2p-webrtc-star": "^0.20.1",
+        "libp2p-websockets": "^0.14.0",
+        "mafmt": "^8.0.0",
+        "merge-options": "^2.0.0",
+        "mortice": "^2.0.0",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.1",
+        "multihashing-async": "^2.0.1",
+        "native-abort-controller": "~0.0.3",
+        "p-queue": "^6.6.1",
+        "parse-duration": "^0.4.4",
+        "peer-id": "^0.14.1",
+        "streaming-iterables": "^5.0.2",
         "uint8arrays": "^1.1.0"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-1.2.0.tgz",
+          "integrity": "sha512-Cl08k4xItix3jvu4cxO/dt2rQ6iUAjO66pTyRMub+WL1VXeAyZydCpD8GqWTPKfdL28U0R0UucmQVsUsBnvCmQ==",
+          "requires": {
+            "abort-controller": "^3.0.0"
+          }
+        },
+        "it-glob": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.8.tgz",
+          "integrity": "sha512-PmIAgb64aJPM6wwT1UTlNDAJnNgdGrvr0vRr3AYCngcUuq1KaAovuz0dQAmUkaXudDG3EQzc7OttuLW9DaL3YQ==",
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "minimatch": "^3.0.4"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+              "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+              "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "libp2p": {
+          "version": "0.29.4",
+          "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.29.4.tgz",
+          "integrity": "sha512-RACD3rvhgBTcLDtILwN8lE2z3GV5OCR1Se/wQ9UPYArSImsoikKjGQMvW0vZl9W3adUqmJOUs7CJWTUvdTAOpw==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "aggregate-error": "^3.0.1",
+            "any-signal": "^1.1.0",
+            "bignumber.js": "^9.0.0",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "err-code": "^2.0.0",
+            "events": "^3.1.0",
+            "hashlru": "^2.3.0",
+            "interface-datastore": "^2.0.0",
+            "ipfs-utils": "^2.2.0",
+            "it-all": "^1.0.1",
+            "it-buffer": "^0.1.2",
+            "it-handshake": "^1.0.1",
+            "it-length-prefixed": "^3.0.1",
+            "it-pipe": "^1.1.0",
+            "it-protocol-buffers": "^0.2.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-interfaces": "^0.5.1",
+            "libp2p-utils": "^0.2.0",
+            "mafmt": "^8.0.0",
+            "merge-options": "^2.0.0",
+            "moving-average": "^1.0.0",
+            "multiaddr": "^8.1.0",
+            "multicodec": "^2.0.0",
+            "multistream-select": "^1.0.0",
+            "mutable-proxy": "^1.0.0",
+            "node-forge": "^0.9.1",
+            "p-any": "^3.0.0",
+            "p-fifo": "^1.0.0",
+            "p-settle": "^4.0.1",
+            "peer-id": "^0.14.2",
+            "protons": "^2.0.0",
+            "retimer": "^2.0.0",
+            "sanitize-filename": "^1.6.3",
+            "streaming-iterables": "^5.0.2",
+            "timeout-abort-controller": "^1.1.1",
+            "varint": "^5.0.0",
+            "xsalsa20": "^1.0.2"
+          },
+          "dependencies": {
+            "ipfs-utils": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+              "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+              "requires": {
+                "abort-controller": "^3.0.0",
+                "any-signal": "^1.1.0",
+                "buffer": "^5.6.0",
+                "err-code": "^2.0.0",
+                "fs-extra": "^9.0.1",
+                "is-electron": "^2.2.0",
+                "iso-url": "^0.4.7",
+                "it-glob": "0.0.8",
+                "it-to-stream": "^0.1.2",
+                "merge-options": "^2.0.0",
+                "nanoid": "^3.1.3",
+                "node-fetch": "^2.6.0",
+                "stream-to-it": "^0.2.0"
+              }
+            }
+          }
+        },
+        "libp2p-interfaces": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.2.tgz",
+          "integrity": "sha512-jnf7D2tJ0eemfQp0j+u4s9fRlILduqXuanCpXt0QSxwqj8LVXUvglQddqoHjH6LGzxBvWXdOAk/ZXEUCcH4ZTw==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-length-prefixed": "^3.1.0",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "it-pushable": "^1.4.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "protons": "^2.0.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2",
+            "uint8arrays": "^1.1.0"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
+      }
+    },
+    "ipfs-core-utils": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.5.4.tgz",
+      "integrity": "sha512-V+OHCkqf/263jHU0Fc9Rx/uDuwlz3PHxl3qu6a5ka/mNi6gucbFuI53jWsevCrOOY9giWMLB29RINGmCV5dFeQ==",
+      "requires": {
+        "any-signal": "^2.0.0",
+        "blob-to-it": "^1.0.1",
+        "browser-readablestream-to-it": "^1.0.1",
+        "cids": "^1.0.0",
+        "err-code": "^2.0.3",
+        "ipfs-utils": "^5.0.0",
+        "it-all": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-peekable": "^1.0.1",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
+        "parse-duration": "^0.4.4",
+        "timeout-abort-controller": "^1.1.1",
+        "uint8arrays": "^1.1.0"
+      }
+    },
+    "ipfs-daemon": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ipfs-daemon/-/ipfs-daemon-0.3.2.tgz",
+      "integrity": "sha512-MBpwB0zpYU17/ZZ4jGMGNvOHx6SYOOZyTfViw+dy/P3JZmeTZBzhPJQOZ0vwwnJI7OIwWscEakJWV4q4c6hrJw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "dlv": "^1.1.3",
+        "ipfs-core": "^0.3.1",
+        "ipfs-http-client": "^48.1.3",
+        "ipfs-http-gateway": "^0.1.4",
+        "ipfs-http-server": "^0.1.4",
+        "ipfs-utils": "^5.0.0",
+        "just-safe-set": "^2.1.0",
+        "libp2p": "^0.29.3",
+        "libp2p-delegated-content-routing": "^0.8.0",
+        "libp2p-delegated-peer-routing": "^0.8.0",
+        "libp2p-webrtc-star": "^0.20.1",
+        "multiaddr": "^8.0.0",
+        "prom-client": "^12.0.0",
+        "prometheus-gc-stats": "^0.6.0"
+      },
+      "dependencies": {
+        "ipfs-http-client": {
+          "version": "48.1.3",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-48.1.3.tgz",
+          "integrity": "sha512-+JV4cdMaTvYN3vd4r6+mcVxV3LkJXzc4kn2ToVbObpVpdqmG34ePf1KlvFF8A9gjcel84WpiP5xCEV/IrisPBA==",
+          "requires": {
+            "any-signal": "^2.0.0",
+            "bignumber.js": "^9.0.0",
+            "cids": "^1.0.0",
+            "debug": "^4.1.1",
+            "form-data": "^3.0.0",
+            "ipfs-core-utils": "^0.5.4",
+            "ipfs-utils": "^5.0.0",
+            "ipld-block": "^0.11.0",
+            "ipld-dag-cbor": "^0.17.0",
+            "ipld-dag-pb": "^0.20.0",
+            "ipld-raw": "^6.0.0",
+            "it-last": "^1.0.4",
+            "it-map": "^1.0.4",
+            "it-tar": "^1.2.2",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.1",
+            "multihashes": "^3.0.1",
+            "nanoid": "^3.1.12",
+            "native-abort-controller": "~0.0.3",
+            "parse-duration": "^0.4.4",
+            "stream-to-it": "^0.2.2",
+            "uint8arrays": "^1.1.0"
+          }
+        },
+        "it-glob": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.8.tgz",
+          "integrity": "sha512-PmIAgb64aJPM6wwT1UTlNDAJnNgdGrvr0vRr3AYCngcUuq1KaAovuz0dQAmUkaXudDG3EQzc7OttuLW9DaL3YQ==",
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "minimatch": "^3.0.4"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+              "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+              "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "libp2p": {
+          "version": "0.29.4",
+          "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.29.4.tgz",
+          "integrity": "sha512-RACD3rvhgBTcLDtILwN8lE2z3GV5OCR1Se/wQ9UPYArSImsoikKjGQMvW0vZl9W3adUqmJOUs7CJWTUvdTAOpw==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "aggregate-error": "^3.0.1",
+            "any-signal": "^1.1.0",
+            "bignumber.js": "^9.0.0",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "err-code": "^2.0.0",
+            "events": "^3.1.0",
+            "hashlru": "^2.3.0",
+            "interface-datastore": "^2.0.0",
+            "ipfs-utils": "^2.2.0",
+            "it-all": "^1.0.1",
+            "it-buffer": "^0.1.2",
+            "it-handshake": "^1.0.1",
+            "it-length-prefixed": "^3.0.1",
+            "it-pipe": "^1.1.0",
+            "it-protocol-buffers": "^0.2.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-interfaces": "^0.5.1",
+            "libp2p-utils": "^0.2.0",
+            "mafmt": "^8.0.0",
+            "merge-options": "^2.0.0",
+            "moving-average": "^1.0.0",
+            "multiaddr": "^8.1.0",
+            "multicodec": "^2.0.0",
+            "multistream-select": "^1.0.0",
+            "mutable-proxy": "^1.0.0",
+            "node-forge": "^0.9.1",
+            "p-any": "^3.0.0",
+            "p-fifo": "^1.0.0",
+            "p-settle": "^4.0.1",
+            "peer-id": "^0.14.2",
+            "protons": "^2.0.0",
+            "retimer": "^2.0.0",
+            "sanitize-filename": "^1.6.3",
+            "streaming-iterables": "^5.0.2",
+            "timeout-abort-controller": "^1.1.1",
+            "varint": "^5.0.0",
+            "xsalsa20": "^1.0.2"
+          },
+          "dependencies": {
+            "any-signal": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-1.2.0.tgz",
+              "integrity": "sha512-Cl08k4xItix3jvu4cxO/dt2rQ6iUAjO66pTyRMub+WL1VXeAyZydCpD8GqWTPKfdL28U0R0UucmQVsUsBnvCmQ==",
+              "requires": {
+                "abort-controller": "^3.0.0"
+              }
+            },
+            "ipfs-utils": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+              "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+              "requires": {
+                "abort-controller": "^3.0.0",
+                "any-signal": "^1.1.0",
+                "buffer": "^5.6.0",
+                "err-code": "^2.0.0",
+                "fs-extra": "^9.0.1",
+                "is-electron": "^2.2.0",
+                "iso-url": "^0.4.7",
+                "it-glob": "0.0.8",
+                "it-to-stream": "^0.1.2",
+                "merge-options": "^2.0.0",
+                "nanoid": "^3.1.3",
+                "node-fetch": "^2.6.0",
+                "stream-to-it": "^0.2.0"
+              }
+            }
+          }
+        },
+        "libp2p-interfaces": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.2.tgz",
+          "integrity": "sha512-jnf7D2tJ0eemfQp0j+u4s9fRlILduqXuanCpXt0QSxwqj8LVXUvglQddqoHjH6LGzxBvWXdOAk/ZXEUCcH4ZTw==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-length-prefixed": "^3.1.0",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "it-pushable": "^1.4.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "protons": "^2.0.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2",
+            "uint8arrays": "^1.1.0"
+          }
+        },
+        "prom-client": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+          "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+          "optional": true,
+          "requires": {
+            "tdigest": "^0.1.1"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "ipfs-http-client": {
       "version": "47.0.1",
       "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-47.0.1.tgz",
       "integrity": "sha512-IAQf+uTLvXw5QFOzbyhu/5lH3rn7jEwwwdCGaNKVhoPI7yfyOV0wRse3hVWejjP1Id0P9mKuMKG8rhcY7pVAdQ==",
+      "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
@@ -4874,15 +4780,154 @@
         "parse-duration": "^0.4.4",
         "stream-to-it": "^0.2.1",
         "uint8arrays": "^1.1.0"
+      },
+      "dependencies": {
+        "any-signal": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-1.2.0.tgz",
+          "integrity": "sha512-Cl08k4xItix3jvu4cxO/dt2rQ6iUAjO66pTyRMub+WL1VXeAyZydCpD8GqWTPKfdL28U0R0UucmQVsUsBnvCmQ==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0"
+          }
+        },
+        "blob-to-it": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.2.tgz",
+          "integrity": "sha512-3/NRr0mUWQTkS71MYEC1teLbT5BTs7RZ6VMPXDV6qApjw3B4TAZspQuvDkYfHuD/XzL5p/RO91x5XRPeJvcCqg==",
+          "dev": true,
+          "requires": {
+            "browser-readablestream-to-it": "^0.0.2"
+          }
+        },
+        "browser-readablestream-to-it": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.2.tgz",
+          "integrity": "sha512-bbiTccngeAbPmpTUJcUyr6JhivADKV9xkNJVLdA91vjdzXyFBZ6fgrzElQsV3k1UNGQACRTl3p4y+cEGG9U48A==",
+          "dev": true
+        },
+        "ipfs-core-utils": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.4.0.tgz",
+          "integrity": "sha512-IBPFvYjWPfVFpCeYUL/0gCUOabdBhh7aO5i4tU//UlF2gVCXPH4PRYlbBH9WM83zE2+o4vDi+dBXsdAI6nLPAg==",
+          "dev": true,
+          "requires": {
+            "blob-to-it": "0.0.2",
+            "browser-readablestream-to-it": "0.0.2",
+            "cids": "^1.0.0",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^3.0.0",
+            "it-all": "^1.0.1",
+            "it-map": "^1.0.2",
+            "it-peekable": "0.0.1",
+            "uint8arrays": "^1.1.0"
+          }
+        },
+        "ipfs-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
+          "integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          }
+        },
+        "ipld-block": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.1.tgz",
+          "integrity": "sha512-lPMfW9tA2hVZw9hdO/YSppTxFmA0+5zxcefBOlCTOn+12RLyy+pdepKMbQw8u0KESFu3pYVmabNRWuFGcgHLLw==",
+          "dev": true,
+          "requires": {
+            "cids": "^1.0.0",
+            "class-is": "^1.1.0"
+          }
+        },
+        "it-glob": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.8.tgz",
+          "integrity": "sha512-PmIAgb64aJPM6wwT1UTlNDAJnNgdGrvr0vRr3AYCngcUuq1KaAovuz0dQAmUkaXudDG3EQzc7OttuLW9DaL3YQ==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "minimatch": "^3.0.4"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+              "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "it-peekable": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-0.0.1.tgz",
+          "integrity": "sha512-fd0JzbNldseeq+FFWthbqYB991UpKNyjPG6LqFhIOmJviCxSompMyoopKIXvLPLY+fBhhv2CT5PT31O/lEnTHw==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
+    },
+    "ipfs-http-gateway": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ipfs-http-gateway/-/ipfs-http-gateway-0.1.4.tgz",
+      "integrity": "sha512-/WuCFC5k31DiIIplGatyJnMmJ74YLnv12xU5DR1rr3E7abKLdyyvaca4cQz3iz2hFcTKvnD3+rRelbXH785JiA==",
+      "requires": {
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/hapi": "^20.0.0",
+        "cids": "^1.0.0",
+        "debug": "^4.1.1",
+        "hapi-pino": "^8.3.0",
+        "ipfs-core-utils": "^0.5.4",
+        "ipfs-http-response": "^0.6.0",
+        "is-ipfs": "^2.0.0",
+        "it-last": "^1.0.4",
+        "it-to-stream": "^0.1.2",
+        "joi": "^17.2.1",
+        "multibase": "^3.0.0",
+        "uint8arrays": "^1.1.0",
+        "uri-to-multiaddr": "^4.0.0"
       }
     },
     "ipfs-http-response": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.6.0.tgz",
-      "integrity": "sha512-x1x4ZGvR0azgasT2ql6qKjiH+aPVjra9rJbNq89KzQVxrQLf9zlEHfLzfL7p8m0iYY4MiD+fW+QZF8xA18Xh2g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.6.1.tgz",
+      "integrity": "sha512-tfvgB0xtciDyIsjrpAooyLvj28rKsnFXAOcPjbWdB8atejo9Rh96bkcHa+mq51KZLo0VpAUYJCVCV38gcIpObQ==",
       "requires": {
         "debug": "^4.1.1",
-        "file-type": "^14.7.1",
+        "file-type": "^16.0.0",
         "filesize": "^6.1.0",
         "it-buffer": "^0.1.1",
         "it-concat": "^1.0.0",
@@ -4893,10 +4938,63 @@
         "p-try-each": "^1.0.1"
       }
     },
+    "ipfs-http-server": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ipfs-http-server/-/ipfs-http-server-0.1.4.tgz",
+      "integrity": "sha512-EyGqwvYpOJHIW6eJ5te2UjjMA073JwabL7oNfCvITFb5ZcRKd76+ox0TDSHlkKUeWN8JP7T/00wYRj+8km2Oyg==",
+      "requires": {
+        "@hapi/boom": "^9.1.0",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hapi": "^20.0.0",
+        "cids": "^1.0.0",
+        "debug": "^4.1.1",
+        "dlv": "^1.1.3",
+        "err-code": "^2.0.3",
+        "hapi-pino": "^8.3.0",
+        "ipfs-core-utils": "^0.5.4",
+        "ipfs-http-gateway": "^0.1.4",
+        "ipfs-unixfs": "^2.0.3",
+        "ipld-dag-pb": "^0.20.0",
+        "it-all": "^1.0.4",
+        "it-drain": "^1.0.3",
+        "it-first": "^1.0.4",
+        "it-last": "^1.0.4",
+        "it-map": "^1.0.4",
+        "it-multipart": "^1.0.5",
+        "it-pipe": "^1.1.0",
+        "it-tar": "^1.2.2",
+        "it-to-stream": "^0.1.2",
+        "iterable-ndjson": "^1.1.0",
+        "joi": "^17.2.1",
+        "just-safe-set": "^2.1.0",
+        "multiaddr": "^8.0.0",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.1",
+        "multihashing-async": "^2.0.1",
+        "native-abort-controller": "~0.0.3",
+        "parse-duration": "^0.4.4",
+        "prom-client": "^12.0.0",
+        "stream-to-it": "^0.2.2",
+        "streaming-iterables": "^5.0.2",
+        "uint8arrays": "^1.1.0",
+        "uri-to-multiaddr": "^4.0.0"
+      },
+      "dependencies": {
+        "prom-client": {
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+          "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+          "optional": true,
+          "requires": {
+            "tdigest": "^0.1.1"
+          }
+        }
+      }
+    },
     "ipfs-repo": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-6.0.3.tgz",
-      "integrity": "sha512-98dAkXAbX0JDGg2ML+h3usEZbQzghF/sCfAM/1Knh/VLdC7xcy34MqZQl+LyRTQEz872iUgk/TqqjkX2Sr2j2A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-7.0.0.tgz",
+      "integrity": "sha512-crTbJiiRpuTytWWZ5SCLmKn1fDsoK5maVSBDfKCy0MWkbrRA0GN1+cQ2Dx8PtxDIRY+bBsicSIE4gH/aZvsPuw==",
       "requires": {
         "bignumber.js": "^9.0.0",
         "bytes": "^3.1.0",
@@ -4908,8 +5006,8 @@
         "err-code": "^2.0.0",
         "interface-datastore": "^2.0.0",
         "ipfs-repo-migrations": "^5.0.3",
-        "ipfs-utils": "^2.3.1",
-        "ipld-block": "^0.10.0",
+        "ipfs-utils": "^4.0.0",
+        "ipld-block": "^0.11.0",
         "it-map": "^1.0.2",
         "it-pushable": "^1.4.0",
         "just-safe-get": "^2.0.0",
@@ -4921,25 +5019,41 @@
         "uint8arrays": "^1.0.0"
       },
       "dependencies": {
-        "ipfs-utils": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
           "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "ipfs-utils": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-4.0.1.tgz",
+          "integrity": "sha512-6mg+S1sbjj+Ff+uoHOhVeC4myfV2tb2sHcdYwfpJ4ZcBo9WfdxSMnWFLiC5bIqByyJuN/g5aWgz3ozjKDzND1Q==",
+          "requires": {
+            "@achingbrain/electron-fetch": "^1.7.2",
             "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
+            "any-signal": "^2.1.0",
+            "buffer": "^6.0.1",
             "err-code": "^2.0.0",
             "fs-extra": "^9.0.1",
             "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "it-to-stream": "^0.1.2",
+            "iso-url": "^1.0.0",
+            "it-glob": "0.0.10",
             "merge-options": "^2.0.0",
             "nanoid": "^3.1.3",
+            "native-abort-controller": "0.0.3",
+            "native-fetch": "^2.0.0",
             "node-fetch": "^2.6.0",
             "stream-to-it": "^0.2.0"
           }
+        },
+        "iso-url": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.0.0.tgz",
+          "integrity": "sha512-n/MsHgKOoHcFrhsxfbM3aaSdUujoFrrZ3537p3RW80AL7axL36acCseoMwIW4tNOl0n0SnkzNyVh4bREwmHoPQ=="
         }
       }
     },
@@ -4963,78 +5077,115 @@
         "protons": "^2.0.0",
         "uint8arrays": "^1.0.0",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "ipfs-unixfs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-2.0.3.tgz",
-      "integrity": "sha512-WpzG/VTqWBPh1cYW3CXk2naElYO3xU0rJnL3SBHbviZ6ZeHRadxR5k0v3/yxPuygs2AwBhaLqBNlV6uB6OCiQw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-2.0.4.tgz",
+      "integrity": "sha512-b8dL8DZSwv0G3WTy8XnH1+Vzj/UydNI4yK/7/j3Ywyx+3yAQW566bdgaW1zvEFWTT3tBK1h3iJrRNHRs3CnBJA==",
       "requires": {
         "err-code": "^2.0.0",
         "protons": "^2.0.0"
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-3.0.4.tgz",
-      "integrity": "sha512-e5rA97JeLaaCBOsuG62MJ2UJZQ3xgd8MoJpNotO37VDXRuE/X0/ny6N8AIxikZ8kHkNmCbclW+B5yQHcmqtRvA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-3.0.7.tgz",
+      "integrity": "sha512-ZYpE8SVLcvxDVb9+aKwthf7a4gRFSHqbEJaVrvVOpeXKSG66WTrI0KQR14sIk0v4SYOaUSWrWVXsSjUbONrVHg==",
       "requires": {
         "cids": "^1.0.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^2.0.3",
-        "ipfs-utils": "^3.0.0",
+        "ipfs-unixfs": "^2.0.4",
+        "ipfs-utils": "^5.0.0",
         "it-last": "^1.0.1",
         "multihashing-async": "^2.0.0"
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-3.0.4.tgz",
-      "integrity": "sha512-2Lz1WSrmmMxBZzk99Uh1o76OZMWzkzgvSpcZcG8AdzpBDdjtsGWWED9FBuU31INT2dZk9Yszm8qxX3a8iYcXJg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-5.0.0.tgz",
+      "integrity": "sha512-bvdnCXwwCj72w/FQ7o6XcvrcbCUgXrruK0UZOfhl/mf44Nv0DWyn1Y4hQF/u63rJvYLQdAMlqniAAtFQpHQhcg==",
       "requires": {
         "bl": "^4.0.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^2.0.3",
-        "ipfs-utils": "^3.0.0",
+        "ipfs-unixfs": "^2.0.4",
+        "ipfs-utils": "^5.0.0",
         "ipld-dag-pb": "^0.20.0",
         "it-all": "^1.0.1",
         "it-batch": "^1.0.3",
         "it-first": "^1.0.1",
         "it-parallel-batch": "^1.0.3",
-        "merge-options": "^2.0.0",
+        "merge-options": "^3.0.3",
         "multihashing-async": "^2.0.0",
         "rabin-wasm": "^0.1.1",
         "uint8arrays": "^1.1.0"
+      },
+      "dependencies": {
+        "merge-options": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+          "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+          "requires": {
+            "is-plain-obj": "^2.1.0"
+          }
+        }
       }
     },
     "ipfs-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
-      "integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-5.0.1.tgz",
+      "integrity": "sha512-28KZPgO4Uf5duT2ORLAYfboUp98iUshDD7yRAfbNxNAR8Dtidfn6o20rZfoXnkri2zKBVIPlJkuCPmPJB+6erg==",
       "requires": {
         "abort-controller": "^3.0.0",
-        "any-signal": "^1.1.0",
-        "buffer": "^5.6.0",
+        "any-signal": "^2.1.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
         "err-code": "^2.0.0",
         "fs-extra": "^9.0.1",
         "is-electron": "^2.2.0",
-        "iso-url": "^0.4.7",
-        "it-glob": "0.0.8",
+        "iso-url": "^1.0.0",
+        "it-glob": "0.0.10",
+        "it-to-stream": "^0.1.2",
         "merge-options": "^2.0.0",
         "nanoid": "^3.1.3",
+        "native-abort-controller": "0.0.3",
+        "native-fetch": "^2.0.0",
         "node-fetch": "^2.6.0",
         "stream-to-it": "^0.2.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "iso-url": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.0.0.tgz",
+          "integrity": "sha512-n/MsHgKOoHcFrhsxfbM3aaSdUujoFrrZ3537p3RW80AL7axL36acCseoMwIW4tNOl0n0SnkzNyVh4bREwmHoPQ=="
+        }
       }
     },
     "ipld": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.27.1.tgz",
-      "integrity": "sha512-rX9TVFk9ZpMtjVdi74yaOgBcGRcz8NhGQHS4t/A4v/4UKp+nBWzDSMSAHpKXM1PGXYdlzYyIsfQMMoimQXVTxw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.28.0.tgz",
+      "integrity": "sha512-lERRFJb17Phi3x06sSirFgCkmSw8lNqOwn2CiBexu0Amo6ICTXULuSZcDeM1AN4+fSzebQgEc8bBIV4zW7dv0A==",
       "requires": {
         "cids": "^1.0.0",
-        "ipld-block": "^0.10.0",
+        "ipld-block": "^0.11.0",
         "ipld-dag-cbor": "^0.17.0",
         "ipld-dag-pb": "^0.20.0",
         "ipld-raw": "^6.0.0",
@@ -5043,27 +5194,12 @@
         "typical": "^6.0.0"
       }
     },
-    "ipld-bitcoin": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.4.0.tgz",
-      "integrity": "sha512-SRcNRMvdeIKlCCMymqas5ZX9tVjAZ/cid2LPd0vWrLtwc1r4liWvHAxbaU/fJa8Xo6neYWuS/XIqaE/yzMAhRw==",
-      "requires": {
-        "bitcoinjs-lib": "^5.0.0",
-        "buffer": "^5.6.0",
-        "cids": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashes": "^3.0.0",
-        "multihashing-async": "^2.0.0",
-        "uint8arrays": "^1.0.0"
-      }
-    },
     "ipld-block": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.1.tgz",
-      "integrity": "sha512-lPMfW9tA2hVZw9hdO/YSppTxFmA0+5zxcefBOlCTOn+12RLyy+pdepKMbQw8u0KESFu3pYVmabNRWuFGcgHLLw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.11.0.tgz",
+      "integrity": "sha512-Kk56OOPmlWAjXfBJXvx2jX5RA6R9qUrcc2JXwF7Y4IL9mlmxcxTNkgcsJYR78DbyMllQbi7yreghjGjtCTYKaw==",
       "requires": {
-        "cids": "^1.0.0",
-        "class-is": "^1.1.0"
+        "cids": "^1.0.0"
       }
     },
     "ipld-dag-cbor": {
@@ -5095,37 +5231,6 @@
         "uint8arrays": "^1.0.0"
       }
     },
-    "ipld-ethereum": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-5.0.1.tgz",
-      "integrity": "sha512-M0n4z4y0LwsBKIvQev8xHOfxwjwR+jl6ot8z2ujScE6MX+inhojw2/vjvoWIk4N7oleNf3sg4ZxBzdttulvPTA==",
-      "requires": {
-        "buffer": "^5.6.0",
-        "cids": "^1.0.0",
-        "ethereumjs-account": "^3.0.0",
-        "ethereumjs-block": "^2.2.1",
-        "ethereumjs-tx": "^2.1.1",
-        "merkle-patricia-tree": "^3.0.0",
-        "multicodec": "^2.0.0",
-        "multihashes": "^3.0.1",
-        "multihashing-async": "^2.0.0",
-        "rlp": "^2.2.4"
-      }
-    },
-    "ipld-git": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.6.1.tgz",
-      "integrity": "sha512-HjKjmMX8vIEMk+isMBaU0/g+xi6LZOQHQ7oFaQ15wUUYLWe5rwkpdr8/3GqHEt3hKdEeWDCX2FqrmQsT9lrQFA==",
-      "requires": {
-        "buffer": "^5.6.0",
-        "cids": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashing-async": "^2.0.1",
-        "smart-buffer": "^4.1.0",
-        "strftime": "^0.10.0",
-        "uint8arrays": "^1.0.0"
-      }
-    },
     "ipld-raw": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-6.0.0.tgz",
@@ -5136,40 +5241,38 @@
         "multihashing-async": "^2.0.0"
       }
     },
-    "ipld-zcash": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.5.0.tgz",
-      "integrity": "sha512-nBeyZ/g/hvP3FQl9IODe6mW+UoO10hQMb3k9elcAuwfromljE/rozoDMiMYagZAm03dkSHsk/YSeEWdWqRKaPQ==",
-      "requires": {
-        "buffer": "^5.6.0",
-        "cids": "^1.0.0",
-        "multicodec": "^2.0.0",
-        "multihashes": "^3.0.1",
-        "multihashing-async": "^2.0.0",
-        "zcash-block": "^2.0.0"
-      }
-    },
     "ipns": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.8.0.tgz",
-      "integrity": "sha512-DbveKyLuiO6GgZ4lILxQ3h+27dV/5MPriDTDny3/WHEaCOYH8Gs64CRP5MBQPQcsnZ2Tg+YkjnUAKX/pWAwNhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.8.1.tgz",
+      "integrity": "sha512-1xyvOhf/oqE9ECVjfZiqAURO3jXdm/jRyluX6lhAPCBImoE5KLTcoJubUkHey+Z8LXJRW+mIxAUMm1FcAyGwTA==",
       "requires": {
-        "debug": "^4.1.1",
-        "err-code": "^2.0.0",
+        "debug": "^4.2.0",
+        "err-code": "^2.0.3",
         "interface-datastore": "^2.0.0",
         "libp2p-crypto": "^0.18.0",
-        "multibase": "^3.0.0",
+        "multibase": "^3.0.1",
         "multihashes": "^3.0.1",
-        "peer-id": "^0.14.0",
+        "peer-id": "^0.14.2",
         "protons": "^2.0.0",
         "timestamp-nano": "^1.0.0",
-        "uint8arrays": "^1.1.0"
+        "uint8arrays": "^2.0.5"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.0.5.tgz",
+          "integrity": "sha512-1HSktgwqtYIwVn1mg3GcnqKhHH9oC4kVgdD/43cxMWwhP8rihKcFPmToDzS1XtbvVvlR8XxTk/DUBf0C83qNIg==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.5"
+          }
+        }
       }
     },
     "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-callable": {
       "version": "1.2.2",
@@ -5188,6 +5291,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
       "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -5232,11 +5344,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-hex-prefixed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
-    },
     "is-installed-globally": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
@@ -5273,10 +5380,20 @@
         "uint8arrays": "^1.1.0"
       }
     },
+    "is-loopback-addr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-1.0.1.tgz",
+      "integrity": "sha512-DhWU/kqY7X2F6KrrVTu7mHlbd2Pbo4D1YkAzasBMjQs6lJAoefxaA6m6CpSX0K6pjt9D0b9PNFI5zduy/vzOYw=="
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+    },
     "is-npm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-      "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA=="
     },
     "is-number": {
       "version": "7.0.0",
@@ -5340,20 +5457,13 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
     },
     "is2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
-      "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.6.tgz",
+      "integrity": "sha512-+Z62OHOjA6k2sUDOKXoZI3EXv7Fb1K52jpTBLbkfx62bcUeSsrTBLhEquCRDKTx0XE5XbHcG/S2vrtE3lnEDsQ==",
       "requires": {
         "deep-is": "^0.1.3",
-        "ip-regex": "^2.1.0",
-        "is-url": "^1.2.2"
-      },
-      "dependencies": {
-        "ip-regex": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
-        }
+        "ip-regex": "^4.1.0",
+        "is-url": "^1.2.4"
       }
     },
     "isarray": {
@@ -5410,9 +5520,9 @@
       }
     },
     "it-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.1.tgz",
-      "integrity": "sha512-ca7tnIqSpPycty9K+x08OwFj9kLSrsXgENn7ry2mNXlFlUkgEZe1/xvBjwnUlUEHvnITMj4Mq7ozPm1VaOm8FQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.2.tgz",
+      "integrity": "sha512-YZtXOe10qBcTDOsz59AscfmsKRoVPYX5AFxCans2L/QL20Jah1H1/+wzWDaJj8zu0KiA9gys3vBoZIZwhsUeeg==",
       "requires": {
         "bl": "^4.0.0"
       }
@@ -5428,37 +5538,12 @@
       "integrity": "sha512-L5ZB5k3Ol5ouAzLHo6fOCtByOy2lNjteNJpZLkE+VgmRt0MbC1ibmBW1AbOt6WzDx/QXFG5C8EEvY2nTXHg+Hw=="
     },
     "it-glob": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.8.tgz",
-      "integrity": "sha512-PmIAgb64aJPM6wwT1UTlNDAJnNgdGrvr0vRr3AYCngcUuq1KaAovuz0dQAmUkaXudDG3EQzc7OttuLW9DaL3YQ==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.10.tgz",
+      "integrity": "sha512-p1PR15djgPV7pxdLOW9j4WcJdla8+91rJdUU2hU2Jm68vkxpIEXK55VHBeH8Lvqh2vqLtM83t8q4BuJxue6niA==",
       "requires": {
-        "fs-extra": "^8.1.0",
+        "fs-extra": "^9.0.1",
         "minimatch": "^3.0.4"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-        }
       }
     },
     "it-goodbye": {
@@ -5498,6 +5583,13 @@
         "bl": "^4.0.2",
         "buffer": "^5.5.0",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "it-map": {
@@ -5532,19 +5624,19 @@
       }
     },
     "it-pb-rpc": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/it-pb-rpc/-/it-pb-rpc-0.1.8.tgz",
-      "integrity": "sha512-YePzUUonithCTIdVKcOeQEn5mpipCg7ZoWsq7jfjXXtAS6gm6R7KzCe6YBV97i6bljU8hGllTG67FiGfweKNKg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/it-pb-rpc/-/it-pb-rpc-0.1.9.tgz",
+      "integrity": "sha512-IMPXz+a+lUEclV5qIlT/1WAjCMIZyqQtMRaKaL8cwgvH2P5LtMJlrbNZr3b4VEONK1H6mqAV1upfMTSSBSrOqA==",
       "requires": {
         "is-buffer": "^2.0.4",
-        "it-handshake": "^1.0.1",
-        "it-length-prefixed": "^3.0.1"
+        "it-handshake": "^1.0.2",
+        "it-length-prefixed": "^3.1.0"
       }
     },
     "it-peekable": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-0.0.1.tgz",
-      "integrity": "sha512-fd0JzbNldseeq+FFWthbqYB991UpKNyjPG6LqFhIOmJviCxSompMyoopKIXvLPLY+fBhhv2CT5PT31O/lEnTHw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.1.tgz",
+      "integrity": "sha512-civpIsgG1N+nYXNhm4Qzb9S89QZOfn4M6wVpH9IIilkJ9UFcDElWQuO1qmjXkdm3M5yg5fk+blW0aSCmu4SGlA=="
     },
     "it-pipe": {
       "version": "1.1.0",
@@ -5593,6 +5685,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-1.0.4.tgz",
       "integrity": "sha512-wycpGeAdQ8WH8eSBkMHN/HMNiQ0Y88XEXo6s6LGJbQZjf9K7ppVzUfCXn7OnxFfUPN0HTWZr+uhthwtrwMTTfw==",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0"
       }
@@ -5635,15 +5728,15 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "joi": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.2.1.tgz",
-      "integrity": "sha512-YT3/4Ln+5YRpacdmfEfrrKh50/kkgX3LgBltjqnlMPIYiZ4hxXZuVJcxmsvxsdeHg9soZfE3qXxHC2tMpCCBOA==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
+      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
       "requires": {
-        "@hapi/address": "^4.1.0",
-        "@hapi/formula": "^2.0.0",
         "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "joycon": {
@@ -5746,16 +5839,36 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
     "jsonfile": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "requires": {
         "graceful-fs": "^4.1.6",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
       }
     },
     "jsonify": {
@@ -5807,15 +5920,6 @@
       "integrity": "sha512-r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==",
       "requires": {
         "randombytes": "^2.0.3"
-      }
-    },
-    "keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-      "requires": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
       }
     },
     "keypair": {
@@ -5903,121 +6007,6 @@
         "typedarray-to-buffer": "~3.1.5"
       }
     },
-    "level-mem": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
-      "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
-      "requires": {
-        "level-packager": "~4.0.0",
-        "memdown": "~3.0.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
-          "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
-          "requires": {
-            "abstract-leveldown": "~5.0.0",
-            "inherits": "^2.0.3"
-          }
-        },
-        "encoding-down": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
-          "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
-          "requires": {
-            "abstract-leveldown": "^5.0.0",
-            "inherits": "^2.0.3",
-            "level-codec": "^9.0.0",
-            "level-errors": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "level-iterator-stream": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
-          "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
-          "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.3.6",
-            "xtend": "^4.0.0"
-          }
-        },
-        "level-packager": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
-          "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
-          "requires": {
-            "encoding-down": "~5.0.0",
-            "levelup": "^3.0.0"
-          }
-        },
-        "levelup": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
-          "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
-          "requires": {
-            "deferred-leveldown": "~4.0.0",
-            "level-errors": "~2.0.0",
-            "level-iterator-stream": "~3.0.0",
-            "xtend": "~4.0.0"
-          }
-        },
-        "memdown": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-          "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-          "requires": {
-            "abstract-leveldown": "~5.0.0",
-            "functional-red-black-tree": "~1.0.1",
-            "immediate": "~3.2.3",
-            "inherits": "~2.0.1",
-            "ltgt": "~2.2.0",
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "level-packager": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
@@ -6033,41 +6022,6 @@
       "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
       "requires": {
         "xtend": "^4.0.2"
-      }
-    },
-    "level-ws": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
-      "requires": {
-        "readable-stream": "~1.0.15",
-        "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
       }
     },
     "leveldown": {
@@ -6126,21 +6080,22 @@
       }
     },
     "libp2p": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.29.0.tgz",
-      "integrity": "sha512-eALoJ0vpsonRwzLpdPY2/272RIl2MImIg2QToqLb+wBChcSQFB4U/r3LU8rZqEaDfRNupOBG/rx67gJTWC0h2Q==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.30.0.tgz",
+      "integrity": "sha512-MUFWnuFAcexb0tRf3Ai8Zt4PUmDwIUCNN2a8bHfei1uaF6jqXAKQxgOJ4dmbGf/nrnKp89NpupjTK9WqYDonrg==",
       "requires": {
         "abort-controller": "^3.0.0",
         "aggregate-error": "^3.0.1",
         "any-signal": "^1.1.0",
         "bignumber.js": "^9.0.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "events": "^3.1.0",
         "hashlru": "^2.3.0",
         "interface-datastore": "^2.0.0",
-        "ipfs-utils": "^2.2.0",
+        "ipfs-utils": "^5.0.1",
         "it-all": "^1.0.1",
         "it-buffer": "^0.1.2",
         "it-handshake": "^1.0.1",
@@ -6148,59 +6103,49 @@
         "it-pipe": "^1.1.0",
         "it-protocol-buffers": "^0.2.0",
         "libp2p-crypto": "^0.18.0",
-        "libp2p-interfaces": "^0.5.1",
-        "libp2p-utils": "^0.2.0",
+        "libp2p-interfaces": "^0.8.1",
+        "libp2p-utils": "^0.2.2",
         "mafmt": "^8.0.0",
         "merge-options": "^2.0.0",
         "moving-average": "^1.0.0",
-        "multiaddr": "^8.0.0",
+        "multiaddr": "^8.1.0",
         "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
         "multistream-select": "^1.0.0",
         "mutable-proxy": "^1.0.0",
         "node-forge": "^0.9.1",
         "p-any": "^3.0.0",
         "p-fifo": "^1.0.0",
         "p-settle": "^4.0.1",
-        "peer-id": "^0.14.0",
+        "peer-id": "^0.14.2",
         "protons": "^2.0.0",
         "retimer": "^2.0.0",
         "sanitize-filename": "^1.6.3",
+        "set-delayed-interval": "^1.0.0",
         "streaming-iterables": "^5.0.2",
         "timeout-abort-controller": "^1.1.1",
         "varint": "^5.0.0",
         "xsalsa20": "^1.0.2"
       },
       "dependencies": {
-        "ipfs-utils": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+        "any-signal": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-1.2.0.tgz",
+          "integrity": "sha512-Cl08k4xItix3jvu4cxO/dt2rQ6iUAjO66pTyRMub+WL1VXeAyZydCpD8GqWTPKfdL28U0R0UucmQVsUsBnvCmQ==",
           "requires": {
-            "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.1",
-            "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "it-to-stream": "^0.1.2",
-            "merge-options": "^2.0.0",
-            "nanoid": "^3.1.3",
-            "node-fetch": "^2.6.0",
-            "stream-to-it": "^0.2.0"
+            "abort-controller": "^3.0.0"
           }
         },
         "libp2p-interfaces": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
-          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.8.1.tgz",
+          "integrity": "sha512-46ttBnPMmg3/I8hPQE08uJtmI6CB2O/+xnOqYJ+yW8m1mqpMNJvQd/yTkoMyNXxJnGhAzC1Vn7IxVrisQhOmNA==",
           "requires": {
+            "@types/bl": "^2.1.0",
             "abort-controller": "^3.0.0",
             "abortable-iterator": "^3.0.0",
             "chai": "^4.2.0",
             "chai-checkmark": "^1.0.1",
-            "class-is": "^1.1.0",
             "debug": "^4.1.1",
             "delay": "^4.3.0",
             "detect-node": "^2.0.4",
@@ -6215,6 +6160,7 @@
             "libp2p-tcp": "^0.15.0",
             "multiaddr": "^8.0.0",
             "multibase": "^3.0.0",
+            "multihashes": "^3.0.1",
             "p-defer": "^3.0.0",
             "p-limit": "^2.3.0",
             "p-wait-for": "^3.1.0",
@@ -6224,6 +6170,11 @@
             "streaming-iterables": "^5.0.2",
             "uint8arrays": "^1.1.0"
           }
+        },
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
         }
       }
     },
@@ -6259,9 +6210,9 @@
       }
     },
     "libp2p-delegated-content-routing": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.7.0.tgz",
-      "integrity": "sha512-eyh6ckCJvAuH+dSI6lKrZ6JLdxazpPUpd2NbRcgmgb6sfpTyFaxhqMa5FHz304mX2FsvE3pX91pTShcL9Aitjg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.8.2.tgz",
+      "integrity": "sha512-3xfrNaX31VB+sj7/u5ZGjhSzbm7l5jCCzlYktEpQyET7JMI8d1ef8FAP3DiWEhbiSfivMMqlfCzfPEMsLxZG7g==",
       "requires": {
         "debug": "^4.1.1",
         "it-all": "^1.0.0",
@@ -6271,9 +6222,9 @@
       }
     },
     "libp2p-delegated-peer-routing": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.7.0.tgz",
-      "integrity": "sha512-bdSnCRts+AMlUv592ZITot+vels1UYQc4WMg8/y+gur1ifEE6GeGWnxneJyCuuzrrjmo2Svr4yY72kuMev+wVQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.8.2.tgz",
+      "integrity": "sha512-q49zSTE7wpagt3FDY6S2e2Rr59kPoTMJAwlPeenZ1ajJLbKXRP26RfraK8RaUUw7mHw0BPo47VQcH7ieDkSO+A==",
       "requires": {
         "cids": "^1.0.0",
         "debug": "^4.1.1",
@@ -6294,9 +6245,9 @@
       },
       "dependencies": {
         "libp2p-interfaces": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
-          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.2.tgz",
+          "integrity": "sha512-jnf7D2tJ0eemfQp0j+u4s9fRlILduqXuanCpXt0QSxwqj8LVXUvglQddqoHjH6LGzxBvWXdOAk/ZXEUCcH4ZTw==",
           "requires": {
             "abort-controller": "^3.0.0",
             "abortable-iterator": "^3.0.0",
@@ -6330,25 +6281,26 @@
       }
     },
     "libp2p-gossipsub": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.6.2.tgz",
-      "integrity": "sha512-jtuZmWwPnhFJYDqBCuKJZNRljZp/gXjvQVvyfmbzNHvSjsVojHqJ8YbeMZdA5207HZ9HQIVL3xx8KgBwY2PAWg==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.6.6.tgz",
+      "integrity": "sha512-oW/d7Y099RmxJ8KKWSlzuh3giuKb94d/VpKCxTqUJlsuA3SHjiOiKCO3oadrK5pkYgFMBXxYEnbZ84tft3MtRQ==",
       "requires": {
         "@types/debug": "^4.1.5",
         "debug": "^4.1.1",
         "denque": "^1.4.1",
         "err-code": "^2.0.0",
         "it-pipe": "^1.0.1",
-        "libp2p-interfaces": "^0.5.1",
+        "libp2p-interfaces": "^0.6.0",
         "peer-id": "^0.14.0",
         "protons": "^2.0.0",
-        "time-cache": "^0.3.0"
+        "time-cache": "^0.3.0",
+        "uint8arrays": "^1.1.0"
       },
       "dependencies": {
         "libp2p-interfaces": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
-          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.6.0.tgz",
+          "integrity": "sha512-KJV+eaExDviPKGRY/UWFSQ186As0VUWy0+MjmbGOA9yGzze8lcZ+4iuR5EM7RMd+ZfuZOX63Nkt0v8BIxBhq+Q==",
           "requires": {
             "abort-controller": "^3.0.0",
             "abortable-iterator": "^3.0.0",
@@ -6382,37 +6334,44 @@
       }
     },
     "libp2p-interfaces": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.4.1.tgz",
-      "integrity": "sha512-LvoK21WtoRxmdLFWGGKMomK4SLXSqcyntoCQ254IOao/EOjis0Za09THENjK+pL1Lk84D1tXLwwK+8pT19EWDw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.7.2.tgz",
+      "integrity": "sha512-uI4vPiwdi9pKScLoAvwMqXiEjUtUACavtqZEvdm36T1PcmzsfDbGDKGCkGoDENQ/kztsggfb/9PoEAiNw3CQxQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "abortable-iterator": "^3.0.0",
-        "buffer": "^5.6.0",
         "chai": "^4.2.0",
         "chai-checkmark": "^1.0.1",
         "class-is": "^1.1.0",
+        "debug": "^4.1.1",
         "delay": "^4.3.0",
         "detect-node": "^2.0.4",
         "dirty-chai": "^2.0.1",
         "err-code": "^2.0.0",
         "it-goodbye": "^2.0.1",
+        "it-length-prefixed": "^3.1.0",
         "it-pair": "^1.0.0",
         "it-pipe": "^1.1.0",
+        "it-pushable": "^1.4.0",
+        "libp2p-crypto": "^0.18.0",
         "libp2p-tcp": "^0.15.0",
         "multiaddr": "^8.0.0",
+        "multibase": "^3.0.0",
+        "multihashes": "^3.0.1",
         "p-defer": "^3.0.0",
         "p-limit": "^2.3.0",
         "p-wait-for": "^3.1.0",
         "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
         "sinon": "^9.0.2",
-        "streaming-iterables": "^5.0.2"
+        "streaming-iterables": "^5.0.2",
+        "uint8arrays": "^1.1.0"
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.20.1.tgz",
-      "integrity": "sha512-khffe6L6O6oU53LO8BrI3bULH4i6FLibvFEyV+7FAPXnFYhTKHa9TsIifkL/MEAfLI0hI9QN4NwMf0DpOLMvDA==",
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.20.4.tgz",
+      "integrity": "sha512-7v4+3bdcoGUyR/8Y5G/Ok9UyhuqghpXFZq5VpW3oph5WtR348snTaBTPkI/8xkQmBxvLIAMxuomp7cMrQaTUyw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "async": "^2.6.2",
@@ -6443,6 +6402,41 @@
         "uint8arrays": "^1.1.0",
         "varint": "^5.0.0",
         "xor-distance": "^2.0.0"
+      },
+      "dependencies": {
+        "libp2p-interfaces": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.4.1.tgz",
+          "integrity": "sha512-LvoK21WtoRxmdLFWGGKMomK4SLXSqcyntoCQ254IOao/EOjis0Za09THENjK+pL1Lk84D1tXLwwK+8pT19EWDw==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "buffer": "^5.6.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2"
+          }
+        },
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "libp2p-mdns": {
@@ -6457,17 +6451,25 @@
       }
     },
     "libp2p-mplex": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.10.0.tgz",
-      "integrity": "sha512-q+zpo12ldm8E+AlnR/LK/j++MM8IkDHi/P19VMPWP07irXe1Pmy/lw6IrSqtDOD8KQc86ipib9d1PI3ALdN8vA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.10.1.tgz",
+      "integrity": "sha512-D7XslSL2MpoQdWFW9m62fZb6U1iq5x18WDIJmBIxM4PKBbhNVsicMAfRGvm/ZntLmxkl2KO8utIcVjYBFg9tsQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "abortable-iterator": "^3.0.0",
         "bl": "^4.0.0",
         "debug": "^4.1.1",
+        "err-code": "^2.0.3",
         "it-pipe": "^1.0.1",
         "it-pushable": "^1.3.1",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "libp2p-noise": {
@@ -6501,30 +6503,10 @@
         "uint8arrays": "^1.1.0"
       }
     },
-    "libp2p-secio": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.13.1.tgz",
-      "integrity": "sha512-1rJBqaCTeKAyA1BedfGCjG8SKB+fOqWXPJLklkaRBcdwmtoNdvCLuLt5So81Z/5sqrbETM1vAQRVdMpyTfPrKw==",
-      "requires": {
-        "bl": "^4.0.0",
-        "debug": "^4.1.1",
-        "it-length-prefixed": "^3.0.1",
-        "it-pair": "^1.0.0",
-        "it-pb-rpc": "^0.1.4",
-        "it-pipe": "^1.1.0",
-        "libp2p-crypto": "^0.18.0",
-        "libp2p-interfaces": "^0.4.0",
-        "multiaddr": "^8.0.0",
-        "multihashing-async": "^2.0.1",
-        "peer-id": "^0.14.0",
-        "protons": "^2.0.0",
-        "uint8arrays": "^1.1.0"
-      }
-    },
     "libp2p-tcp": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.1.tgz",
-      "integrity": "sha512-alvgZ3lSNUyiz4vJOqvm6RpMQN9d17gSJa+VT+2pYLGf82o8pX3QvyhltMkBG7u9I+qZAkD6L27s8o0h38dpOg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.2.tgz",
+      "integrity": "sha512-sJwzP6+iWj2QYwo3ab8DycWWGbjxHFm6Cv0mDj8nzkiebLnm36wMs5wXVDiSgerPITAOHE9SPTOOqaST8Y1rnw==",
       "requires": {
         "abortable-iterator": "^3.0.0",
         "class-is": "^1.1.0",
@@ -6537,47 +6519,42 @@
       }
     },
     "libp2p-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.2.0.tgz",
-      "integrity": "sha512-tZmqu27SULiIvfV+RZg5WOomxXIqM/SEd9FwKuirYTHHU1eet2bLzVQBhigatrdyQxebqi8GVnwbKmqdRElgCA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.2.3.tgz",
+      "integrity": "sha512-9BoMCgvJF7LJ+JVMaHtqfCqhZN4i/sx0DrY6lf9U0Rq9uUgQ9qTai2O9LXcfr1LOS3OMMeRLsKk25MMgsf7W3w==",
       "requires": {
         "abortable-iterator": "^3.0.0",
-        "debug": "^4.1.1",
+        "debug": "^4.2.0",
         "err-code": "^2.0.3",
         "ip-address": "^6.1.0",
-        "multiaddr": "^8.0.0"
+        "is-loopback-addr": "^1.0.0",
+        "multiaddr": "^8.0.0",
+        "private-ip": "^2.1.1"
       }
     },
     "libp2p-webrtc-direct": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-direct/-/libp2p-webrtc-direct-0.4.0.tgz",
-      "integrity": "sha512-VrxdcGevEYPcr140iB7dSECxVVplFuBhCPv2k/BkJ/zpHjMoa9f6y04ANgAVvzwrL/sGF1aYtL3f8r73TY8jGQ==",
+      "version": "github:libp2p/js-libp2p-webrtc-direct#b8cc1f2b4f17975a3fc2b5be51b34ad4d79d4a4e",
+      "from": "github:libp2p/js-libp2p-webrtc-direct#chore/update-breaking-deps",
       "requires": {
-        "abortable-iterator": "^2.1.0",
+        "abortable-iterator": "^3.0.0",
         "class-is": "^1.1.0",
         "concat-stream": "^2.0.0",
+        "debug": "^4.3.1",
         "detect-node": "^2.0.4",
         "err-code": "^2.0.0",
-        "interface-transport": "github:libp2p/interface-transport#chore/skip-abort-while-reading-for-webrtc",
-        "libp2p-utils": "^0.1.0",
-        "mafmt": "^7.0.0",
-        "multibase": "~0.6.0",
+        "libp2p-interfaces": "github:libp2p/js-interfaces#chore/skip-abort-while-reading-for-webrtc",
+        "libp2p-utils": "^0.2.3",
+        "libp2p-webrtc-peer": "^10.0.1",
+        "mafmt": "^8.0.1",
+        "multibase": "^3.1.0",
         "once": "^1.4.0",
         "request": "^2.88.0",
-        "simple-peer": "9.6.0",
-        "stream-to-it": "^0.1.1",
-        "wrtc": "~0.4.2",
+        "stream-to-it": "^0.2.2",
+        "uint8arrays": "^1.1.0",
+        "wrtc": "~0.4.6",
         "xhr": "^2.5.0"
       },
       "dependencies": {
-        "abortable-iterator": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-2.1.0.tgz",
-          "integrity": "sha512-5G9dgRoN7EUR3QTMo9A/iEQ58nD2vFJl8xV8lZvX3hWELLc6AXGxUVvjv2dGBHUXa77hT45bzmoo3XGeAgAFXg==",
-          "requires": {
-            "get-iterator": "^1.0.2"
-          }
-        },
         "cids": {
           "version": "0.8.3",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
@@ -6601,45 +6578,101 @@
             }
           }
         },
-        "concat-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "libp2p-utils": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.1.3.tgz",
-          "integrity": "sha512-ApiQu45O+wTArSuAA8I0FR+CRf9lqoVTR1iGqSPx57x3iCzAtf3uKEOFxUDkgdWCnhpo04VKr2TLzxEYvkxd/w==",
-          "requires": {
-            "abortable-iterator": "^3.0.0",
-            "debug": "^4.1.1",
-            "err-code": "^2.0.3",
-            "ip-address": "^6.1.0",
-            "multiaddr": "^7.5.0"
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.2.1",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.0.0",
+            "ursa-optional": "^0.10.1"
           },
           "dependencies": {
-            "abortable-iterator": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-3.0.0.tgz",
-              "integrity": "sha512-7KqcPPnMhfot4GrEjK51zesS4Ye/lUCHBgYt3oRxIlU24HO3mVxBwEo9niNyfHqoWKqWLuZTc3zErNomdHA+ag==",
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
               "requires": {
-                "get-iterator": "^1.0.2"
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
               }
             }
           }
         },
-        "mafmt": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
-          "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
+        "libp2p-interfaces": {
+          "version": "github:libp2p/js-interfaces#28eeaf697732f20022ad5b3339a792f48aec04a5",
+          "from": "github:libp2p/js-interfaces#chore/skip-abort-while-reading-for-webrtc",
           "requires": {
-            "multiaddr": "^7.3.0"
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "buffer": "^5.5.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.0.1",
+            "libp2p-tcp": "^0.14.1",
+            "multiaddr": "^7.1.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.2.2",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.13.3",
+            "peer-info": "^0.17.0",
+            "sinon": "^9.0.0",
+            "streaming-iterables": "^4.1.0"
+          }
+        },
+        "libp2p-tcp": {
+          "version": "0.14.6",
+          "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.6.tgz",
+          "integrity": "sha512-DeOdaH5QGVMKZflJmZq3dSWROxzD/YU1MFDxfi+DT4JVMcxfVMd+SpVEPMyk2wyA28H4AdGIRsH78yPjlFIyZQ==",
+          "requires": {
+            "abortable-iterator": "^3.0.0",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "err-code": "^2.0.0",
+            "libp2p-utils": "^0.1.2",
+            "mafmt": "^7.1.0",
+            "multiaddr": "^7.5.0",
+            "stream-to-it": "^0.2.2"
+          },
+          "dependencies": {
+            "libp2p-utils": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.1.3.tgz",
+              "integrity": "sha512-ApiQu45O+wTArSuAA8I0FR+CRf9lqoVTR1iGqSPx57x3iCzAtf3uKEOFxUDkgdWCnhpo04VKr2TLzxEYvkxd/w==",
+              "requires": {
+                "abortable-iterator": "^3.0.0",
+                "debug": "^4.1.1",
+                "err-code": "^2.0.3",
+                "ip-address": "^6.1.0",
+                "multiaddr": "^7.5.0"
+              }
+            },
+            "mafmt": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
+              "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
+              "requires": {
+                "multiaddr": "^7.3.0"
+              }
+            }
           }
         },
         "multiaddr": {
@@ -6664,15 +6697,6 @@
                 "buffer": "^5.5.0"
               }
             }
-          }
-        },
-        "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
           }
         },
         "multicodec": {
@@ -6705,14 +6729,53 @@
             }
           }
         },
-        "stream-to-it": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.1.1.tgz",
-          "integrity": "sha512-pGC30bjA1H6c7oD8XeYpRtExLZeOCYdYArjMTHk8kdILVb3QaZcwBNvdCA5GSy8t061LbodW7mu4CWoP0JU6dA==",
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
           "requires": {
-            "get-iterator": "^1.0.2",
-            "p-defer": "^3.0.0"
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
+        },
+        "peer-id": {
+          "version": "0.13.13",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.13.tgz",
+          "integrity": "sha512-5FpBXN6PDTcHs51gkHWPf0OIQZAO3Z10i6lWc+GaoxTU4bQHtsoKFnhxoXo5Ze04JblpzIrtowkluLSCLP1WYg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "^0.8.0",
+            "class-is": "^1.1.0",
+            "libp2p-crypto": "^0.17.7",
+            "minimist": "^1.2.5",
+            "multihashes": "^1.0.1",
+            "protons": "^1.0.2"
+          }
+        },
+        "protons": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+          "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA=="
+        },
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
         }
       }
     },
@@ -6730,31 +6793,31 @@
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.20.1.tgz",
-      "integrity": "sha512-VQNL24A3rN1/9U0fTO8MqUx3+6d99iz/HvPI3p+IzHb6MgBe7er+rgbvRep7uheZ2894IxiJI848Vs0ZNypn2w==",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.20.6.tgz",
+      "integrity": "sha512-XR7h/UYT694IuPj4xM3ik4aH2j2HqzHB4KEOXeE2bpsQ0myVPri3qG0BBrv+vkFCCK7NWu9L4EARGSgqB+qdCw==",
       "requires": {
         "@hapi/hapi": "^20.0.0",
-        "@hapi/inert": "^6.0.2",
+        "@hapi/inert": "^6.0.3",
         "abortable-iterator": "^3.0.0",
         "class-is": "^1.1.0",
-        "debug": "^4.1.1",
-        "err-code": "^2.0.0",
-        "ipfs-utils": "^3.0.0",
-        "it-pipe": "^1.0.1",
-        "libp2p-utils": "^0.2.0",
+        "debug": "^4.2.0",
+        "err-code": "^2.0.3",
+        "ipfs-utils": "^5.0.0",
+        "it-pipe": "^1.1.0",
+        "libp2p-utils": "^0.2.1",
         "libp2p-webrtc-peer": "^10.0.1",
         "mafmt": "^8.0.0",
         "menoetius": "0.0.2",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.5",
         "multiaddr": "^8.0.0",
         "p-defer": "^3.0.0",
-        "peer-id": "^0.14.0",
-        "prom-client": "^12.0.0",
+        "peer-id": "^0.14.2",
+        "prom-client": "^13.0.0",
         "socket.io": "^2.3.0",
         "socket.io-client": "^2.3.0",
         "stream-to-it": "^0.2.2",
-        "streaming-iterables": "^5.0.2"
+        "streaming-iterables": "^5.0.3"
       }
     },
     "libp2p-websockets": {
@@ -6963,13 +7026,21 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
-    },
-    "lolex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
-      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg=="
     },
     "long": {
       "version": "4.0.0",
@@ -6995,9 +7066,9 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-8.0.0.tgz",
-      "integrity": "sha512-MdaeaqZxjoYYWvlhr1GQ7sbsR3+L3s8QL0VtCuja+Iax3EhqAEgluSWPJezSDLyns7Ds4DGRyoq5+eIU7UDang==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-8.0.2.tgz",
+      "integrity": "sha512-6xkkWsEjNzhWeB3qovvtDZ3DXGsrlytY6mjIoqs9U6VH2dUo2OVSpYvrSDl0H2y1iaPSKQDqYSsEskgowJ1g6w==",
       "requires": {
         "multiaddr": "^8.0.0"
       }
@@ -7021,38 +7092,11 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "memdown": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
-      "requires": {
-        "abstract-leveldown": "~2.7.1",
-        "functional-red-black-tree": "^1.0.1",
-        "immediate": "^3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "menoetius": {
@@ -7091,92 +7135,6 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
-    "merkle-lib": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
-      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
-    },
-    "merkle-patricia-tree": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
-      "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
-      "requires": {
-        "async": "^2.6.1",
-        "ethereumjs-util": "^5.2.0",
-        "level-mem": "^3.0.1",
-        "level-ws": "^1.0.0",
-        "readable-stream": "^3.0.6",
-        "rlp": "^2.0.0",
-        "semaphore": ">=1.0.1"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "level-ws": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
-          "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.8",
-            "xtend": "^4.0.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        }
-      }
-    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -7190,6 +7148,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -7206,18 +7165,11 @@
       "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "requires": {
-        "mime-db": "1.44.0"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
-        }
+        "mime-db": "1.45.0"
       }
     },
     "mimic-fn": {
@@ -7406,6 +7358,11 @@
             "path-is-absolute": "^1.0.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -7546,6 +7503,18 @@
         "xtend": "^4.0.0"
       },
       "dependencies": {
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -7612,16 +7581,25 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiaddr": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
-      "integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.1.2.tgz",
+      "integrity": "sha512-r13IzW8+Sv9zab9Gt8RPMIN2WkptIPq99EpAzg4IbJ/zTELhiEwXWr9bAmEatSCI4j/LSA6ESJzvz95JZ+ZYXQ==",
       "requires": {
         "cids": "^1.0.0",
         "class-is": "^1.1.0",
+        "dns-over-http-resolver": "^1.0.0",
+        "err-code": "^2.0.3",
         "is-ip": "^3.1.0",
         "multibase": "^3.0.0",
         "uint8arrays": "^1.1.0",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "multiaddr-to-uri": {
@@ -7633,12 +7611,12 @@
       }
     },
     "multibase": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-      "integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.0.tgz",
+      "integrity": "sha512-Z+pThrpbS7ckQ2DwW5mPiwCGe1a94f8DWi/OxmbyeRednVOyUKmLSE+60kL/WHFYwWnaD1OakXGk3PYI1NkMFw==",
       "requires": {
         "@multiformats/base-x": "^4.0.1",
-        "web-encoding": "^1.0.2"
+        "web-encoding": "^1.0.4"
       }
     },
     "multicast-dns": {
@@ -7651,65 +7629,22 @@
       }
     },
     "multicodec": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.1.tgz",
-      "integrity": "sha512-YDYeWn9iGa76hOHAyyZa0kbt3tr5FLg1ZXUHrZUJltjnxxdbTIbHnxWLd2zTcMOjdT3QyO+Xs4bQgJUcC2RWUA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.1.0.tgz",
+      "integrity": "sha512-7AYpK/avswOWvnqQ9/jOkQCS7Fp4aKxw5ojvn5gyK2VQTZz3YVXeLMzoIZDBy745JSfJMXkTS0ptnHci5Mt1mA==",
       "requires": {
-        "uint8arrays": "1.0.0",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "uint8arrays": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
-          "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
-          "requires": {
-            "multibase": "^3.0.0",
-            "web-encoding": "^1.0.2"
-          }
-        }
+        "uint8arrays": "1.1.0",
+        "varint": "^6.0.0"
       }
     },
     "multihashes": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
-      "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.0.tgz",
+      "integrity": "sha512-snU+w6aZy5bTrrqIHW3wkT0MfHmxcpOsaVNJt0NzUnseksbjFDVUZjSmhDMAVOVnIdLMS7xHjo55pKlBIGmC3g==",
       "requires": {
-        "multibase": "^3.0.0",
+        "multibase": "^3.1.0",
         "uint8arrays": "^1.0.0",
-        "varint": "^5.0.0"
-      }
-    },
-    "multihashing": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/multihashing/-/multihashing-0.3.3.tgz",
-      "integrity": "sha512-jXVWf5uqnZUhc1mLFPWOssuOpkj/A/vVLKrtEscD1PzSLobXYocBy9Gqa/Aw4229/heGnl0RBHU3cD53MbHUig==",
-      "requires": {
-        "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.14",
-        "webcrypto": "~0.1.1"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          }
-        }
+        "varint": "^6.0.0"
       }
     },
     "multihashing-async": {
@@ -7757,24 +7692,40 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanoid": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
     },
     "napi-macros": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
+    "native-abort-controller": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-0.0.3.tgz",
+      "integrity": "sha512-YIxU5nWqSHG1Xbu3eOu3pdFRD882ivQpIcu6AiPVe2oSVoRbfYW63DVkZm3g1gHiMtZSvZzF6THSzTGEBYl8YA==",
+      "requires": {
+        "globalthis": "^1.0.1"
+      }
+    },
+    "native-fetch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-2.0.1.tgz",
+      "integrity": "sha512-gv4Bea+ga9QdXINurpkEqun3ap3vnB+WYoe4c8ddqUYEH7B2h6iD39RF8uVN7OwmSfMY3RDxkvBnoI4e2/vLXQ==",
+      "requires": {
+        "globalthis": "^1.0.1"
+      }
+    },
     "needle": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -7782,11 +7733,19 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         }
       }
@@ -7802,9 +7761,9 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "nightwatch": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-1.4.3.tgz",
-      "integrity": "sha512-n57K99jt3rFruQ5Drjg1bxHeorjHrfyNhNhehL5Gg/p+PT+A5LKZVZkoF73owKc3y7KGhCTvjcLxPAyLvS6J8Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-1.5.1.tgz",
+      "integrity": "sha512-tFhzV7JyLjI+Rq7xXLaRUQ/hExP87GlMYiAlhAYaODpyQSIl8O7/yf7gAUYQd3H7m3n+tnwFFsuE0GaxvCdoZA==",
       "requires": {
         "assertion-error": "^1.1.0",
         "chai-nightwatch": "^0.4.0",
@@ -7990,20 +7949,15 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-    },
     "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -8014,22 +7968,16 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-        }
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
+      "integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "observable-webworkers": {
@@ -8059,25 +8007,9 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
     },
     "opener": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        }
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A=="
     },
     "optional": {
       "version": "0.1.4",
@@ -8136,9 +8068,9 @@
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "log-symbols": {
           "version": "3.0.0",
@@ -8166,11 +8098,6 @@
                 "supports-color": "^5.3.0"
               }
             },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-            },
             "supports-color": {
               "version": "5.5.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -8179,14 +8106,6 @@
                 "has-flag": "^3.0.0"
               }
             }
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }
@@ -8289,12 +8208,12 @@
       }
     },
     "p-queue": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.1.tgz",
-      "integrity": "sha512-miQiSxLYPYBxGkrldecZC18OTLjdUqnlRebGzPRiVxB8mco7usCmm7hFuxiTvp93K18JnLtE4KMMycjAu/cQQg==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "requires": {
         "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.1.0"
+        "p-timeout": "^3.2.0"
       }
     },
     "p-reflect": {
@@ -8347,9 +8266,9 @@
       "integrity": "sha512-WyUjRAvK4CG9DUW21ZsNYcBj6guN7pgZAOFR8mUtyNXyPC5WUo3L48nxI5TsGEZ+VJhZXzyeH/Sxi2lxYcPp3A=="
     },
     "p-wait-for": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
-      "integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
+      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
       "requires": {
         "p-timeout": "^3.0.0"
       }
@@ -8369,6 +8288,14 @@
         "socks-proxy-agent": "^4.0.1"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "https-proxy-agent": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
@@ -8379,9 +8306,9 @@
           },
           "dependencies": {
             "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "version": "3.2.7",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
               "requires": {
                 "ms": "^2.1.1"
               }
@@ -8439,6 +8366,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
       "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "dev": true,
       "requires": {
         "asn1.js": "^5.2.0",
         "browserify-aes": "^1.0.0",
@@ -8458,20 +8386,14 @@
       "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
     },
     "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
     },
     "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
     },
     "path-browserify": {
       "version": "0.0.1",
@@ -8528,6 +8450,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
       "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -8537,9 +8460,9 @@
       }
     },
     "peek-readable": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
-      "integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.1.tgz",
+      "integrity": "sha512-QHJag0oYYPVkx6rVPEgCLEUMo6VRYbV3GUrqy00lxXJBEIw9LhPCP5MQI6mEfahJO9KYUP8W8qD8kC0V9RyZFQ=="
     },
     "peer-id": {
       "version": "0.14.2",
@@ -8553,6 +8476,177 @@
         "multihashes": "^3.0.1",
         "protons": "^2.0.0",
         "uint8arrays": "^1.1.0"
+      }
+    },
+    "peer-info": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.17.5.tgz",
+      "integrity": "sha512-ebbbnvdCnb0onWuW+QNXO4KvLPuQ+kih3zezhov2uxHqA6VLbtzMUyQ06IHtwYLr50AYYWyBOSn17g4zEBsFpw==",
+      "requires": {
+        "mafmt": "^7.1.0",
+        "multiaddr": "^7.3.0",
+        "peer-id": "~0.13.2",
+        "unique-by": "^1.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.2.1",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.0.0",
+            "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "mafmt": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
+          "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
+          "requires": {
+            "multiaddr": "^7.3.0"
+          }
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "peer-id": {
+          "version": "0.13.13",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.13.tgz",
+          "integrity": "sha512-5FpBXN6PDTcHs51gkHWPf0OIQZAO3Z10i6lWc+GaoxTU4bQHtsoKFnhxoXo5Ze04JblpzIrtowkluLSCLP1WYg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "^0.8.0",
+            "class-is": "^1.1.0",
+            "libp2p-crypto": "^0.17.7",
+            "minimist": "^1.2.5",
+            "multihashes": "^1.0.1",
+            "protons": "^1.0.2"
+          }
+        },
+        "protons": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+          "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "pem-jwk": {
@@ -8579,11 +8673,11 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pino": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.6.1.tgz",
-      "integrity": "sha512-DOgm7rn6ctBkBYemHXSLj7+j3o3U1q1FWBXbHcprur8mA93QcJSycEkEqhqKiFB9Mx/3Qld2FGr6+9yfQza0kA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.9.0.tgz",
+      "integrity": "sha512-9RrRJsKOsgj50oGoR/y4EEVyUjMb/eRu8y4hjwPqM6q214xsxSxY/IKB+aEEv0slqNd4U0RVRfivKfy83UxgUQ==",
       "requires": {
-        "fast-redact": "^2.0.0",
+        "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^2.4.2",
@@ -8592,9 +8686,9 @@
       }
     },
     "pino-pretty": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.2.1.tgz",
-      "integrity": "sha512-WyO/n6c6T2gj0ioYGFUFbrvyUoERK37Lu0liLxMIJnp1YaaG+XZBU2TAQB0yVJNb+7T+oDh9t8HGMzk00jy+tw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.3.0.tgz",
+      "integrity": "sha512-uEc9SUCCGVEs0goZvyznKXBHtI1PNjGgqHviJHxOCEFEWZN6Z/IQKv5pO9gSdm/b+WfX+/dfheWhtZUyScqjlQ==",
       "requires": {
         "@hapi/bourne": "^2.0.0",
         "args": "^5.0.1",
@@ -8625,9 +8719,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -8653,15 +8747,23 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "pretty-bytes": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
+      "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA=="
+    },
+    "private-ip": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-2.1.1.tgz",
+      "integrity": "sha512-csxTtREJ7254nnUF14hjOrnd/vZH78vTS5opec6IDVZRwY3omKDcNL/r+vfxFZnCRsrBWVA8B0Q95lgMGrFuZQ==",
+      "requires": {
+        "is-ip": "^3.1.0",
+        "netmask": "^1.0.6"
+      }
     },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -8674,9 +8776,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "prom-client": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.0.0.tgz",
+      "integrity": "sha512-M7ZNjIO6x+2R/vjSD13yjJPjpoZA8eEwH2Bp2Re0/PvzozD7azikv+SaBtZes4Q1ca/xHjZ4RSCuTag3YZLg1A==",
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -8716,9 +8818,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
-      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -8736,9 +8838,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
-          "integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ=="
+          "version": "13.13.39",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.39.tgz",
+          "integrity": "sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw=="
         }
       }
     },
@@ -8756,6 +8858,13 @@
         "signed-varint": "^2.0.1",
         "uint8arrays": "^1.0.0",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "proxy-agent": {
@@ -8773,6 +8882,14 @@
         "socks-proxy-agent": "^4.0.1"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "https-proxy-agent": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
@@ -8783,9 +8900,9 @@
           },
           "dependencies": {
             "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "version": "3.2.7",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
               "requires": {
                 "ms": "^2.1.1"
               }
@@ -8826,6 +8943,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -8833,24 +8951,6 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "pull-defer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
-    },
-    "pull-stream": {
-      "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
-    },
-    "pull-stream-to-async-iterator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-stream-to-async-iterator/-/pull-stream-to-async-iterator-1.0.2.tgz",
-      "integrity": "sha512-c3KRs2EneuxP7b6pG9fvQTIjatf33RbIErhbQ75s5r2MI6E8R74NZC1nJgXc8kcmqiQxmr+TWY+WwK2mWaUnlA==",
-      "requires": {
-        "pull-stream": "^3.6.9"
       }
     },
     "pump": {
@@ -8868,25 +8968,17 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
-      "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
       "requires": {
         "escape-goat": "^2.0.0"
       }
     },
-    "pushdata-bitcoin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
-      "requires": {
-        "bitcoin-ops": "^1.3.0"
-      }
-    },
     "qs": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-      "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -8901,9 +8993,9 @@
       "dev": true
     },
     "queue-microtask": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
-      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
     },
     "quick-format-unescaped": {
       "version": "4.0.1",
@@ -8935,6 +9027,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -8949,6 +9042,16 @@
         "http-errors": "1.7.3",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "rc": {
@@ -9027,14 +9130,26 @@
       }
     },
     "readable-web-to-node-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
-      "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.1.tgz",
+      "integrity": "sha512-4zDC6CvjUyusN7V0QLsXVB7pJCD9+vtrM9bYDRv6uBQ+SKfx36rp5AFNPRgh9auKRul/a1iFZJYXcCbwRL+SaA==",
+      "requires": {
+        "@types/readable-stream": "^2.3.9",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
     },
     "registry-auth-token": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
-      "integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
       "requires": {
         "rc": "^1.2.8"
       }
@@ -9088,11 +9203,6 @@
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         }
       }
     },
@@ -9136,11 +9246,12 @@
       "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs="
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -9177,9 +9288,9 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -9188,17 +9299,10 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "rlp": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
-      "requires": {
-        "bn.js": "^4.11.1"
       }
     },
     "run": {
@@ -9210,9 +9314,9 @@
       }
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -9237,11 +9341,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
-    "scrypt-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
-    },
     "secp256k1": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
@@ -9255,18 +9354,15 @@
     "secure-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
-      "dev": true
-    },
-    "semaphore": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
+      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM="
     },
     "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -9288,15 +9384,15 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "set-delayed-interval": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-delayed-interval/-/set-delayed-interval-1.0.0.tgz",
+      "integrity": "sha512-29fhAwuZlLcuBnW/EwxvLcg2D3ELX+VBDNhnavs3YYkab72qmrcSeQNVdzl8EcPPahGQXhBM6MKdPLCQGMDakw=="
+    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -9307,6 +9403,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -9351,9 +9448,9 @@
       "dev": true
     },
     "shortid": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
-      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
       "requires": {
         "nanoid": "^2.1.0"
       },
@@ -9376,6 +9473,13 @@
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
       "requires": {
         "varint": "~5.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "simple-concat": {
@@ -9384,45 +9488,17 @@
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true
     },
-    "simple-peer": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.6.0.tgz",
-      "integrity": "sha512-NYqSKPu75xhkZYKGJhCbLCG5kfBtDHf8U9ddk4EKFfYNU7XgIisov+V8wMbVVgyMCfn8pm8uOqQQmE50FPDFWA==",
-      "requires": {
-        "debug": "^4.0.1",
-        "get-browser-rtc": "^1.0.0",
-        "queue-microtask": "^1.1.0",
-        "randombytes": "^2.0.3",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "sinon": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
-      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.3.tgz",
+      "integrity": "sha512-m+DyAWvqVHZtjnjX/nuShasykFeiZ+nPuEfD4G3gpvKGkXRhkF/6NSt2qN2FjZhfrcHXFzUzI+NLnk+42fnLEw==",
       "requires": {
-        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.1.0",
+        "@sinonjs/samsam": "^5.3.0",
         "diff": "^4.0.2",
         "nise": "^4.0.4",
         "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "slash": {
@@ -9436,15 +9512,15 @@
       "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
     },
     "socket.io": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
-      "integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.4.1.tgz",
+      "integrity": "sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==",
       "requires": {
         "debug": "~4.1.0",
-        "engine.io": "~3.4.0",
+        "engine.io": "~3.5.0",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.3.0",
+        "socket.io-client": "2.4.0",
         "socket.io-parser": "~3.4.0"
       },
       "dependencies": {
@@ -9464,32 +9540,29 @@
       "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
     },
     "socket.io-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
+      "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
       "requires": {
         "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "~4.1.0",
-        "engine.io-client": "~3.4.0",
+        "component-emitter": "~1.3.0",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.5.0",
         "has-binary2": "~1.0.2",
-        "has-cors": "1.1.0",
         "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
         "socket.io-parser": "~3.3.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.0.0"
           }
         },
         "isarray": {
@@ -9497,29 +9570,19 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "socket.io-parser": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-          "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+          "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
           "requires": {
-            "component-emitter": "1.2.1",
+            "component-emitter": "~1.3.0",
             "debug": "~3.1.0",
             "isarray": "2.0.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
           }
         }
       }
@@ -9534,6 +9597,11 @@
         "isarray": "2.0.1"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -9587,9 +9655,9 @@
       }
     },
     "sort-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.0.0.tgz",
-      "integrity": "sha512-hlJLzrn/VN49uyNkZ8+9b+0q9DjmmYcYOnbMQtpkLrYpPwRApDPZfmqbUfJnAA3sb/nRib+nDot7Zi/1ER1fuA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
       "requires": {
         "is-plain-obj": "^2.0.0"
       }
@@ -9825,11 +9893,6 @@
       "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.3.tgz",
       "integrity": "sha512-1AgrKjHTvaaK+iA+N3BuTXQWVb7Adyb6+v8yIW3SCTwlBVYEbm76mF8Mf0/IVo+DOk7hoeELOURBKTCMhe/qow=="
     },
-    "strftime": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
-      "integrity": "sha1-s/D6QZKVICpaKJ9ta+n0kJphcZM="
-    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -9841,21 +9904,21 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string_decoder": {
@@ -9879,27 +9942,19 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
-    "strip-hex-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "requires": {
-        "is-hex-prefixed": "1.0.0"
-      }
-    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "strtok3": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.4.tgz",
-      "integrity": "sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.6.tgz",
+      "integrity": "sha512-fVxvAEKDwHFfbQO1yKxKBPfkWZyBr0Zf20UQ/mblbkAQe5h0Xdd2jDb3Mh7yRZd7LSItJ9JWgQWelpEmVoBe2g==",
       "requires": {
         "@tokenizer/token": "^0.1.1",
         "@types/debug": "^4.1.5",
-        "peek-readable": "^3.1.0"
+        "peek-readable": "^3.1.1"
       }
     },
     "subarg": {
@@ -9912,11 +9967,11 @@
       }
     },
     "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "syntax-error": {
@@ -9958,22 +10013,12 @@
       }
     },
     "tcp-port-used": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
-      "integrity": "sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
+      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
       "requires": {
-        "debug": "4.1.0",
-        "is2": "2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
+        "debug": "4.3.1",
+        "is2": "^2.0.6"
       }
     },
     "tdigest": {
@@ -9984,70 +10029,23 @@
         "bintrees": "1.0.1"
       }
     },
-    "temp": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
-      "integrity": "sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==",
-      "requires": {
-        "rimraf": "~2.6.2"
-      }
-    },
     "term-size": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="
     },
     "test-ipfs-example": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/test-ipfs-example/-/test-ipfs-example-2.0.3.tgz",
-      "integrity": "sha512-eqhDGDEfw+pvLkgPy+qFeIm5tPipothP2tN/zQTkw4qlAHP8TLoxB22Iqsvxc6fNaxjm4nJeDZSLvjwFNHjKfg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/test-ipfs-example/-/test-ipfs-example-2.1.0.tgz",
+      "integrity": "sha512-7PlNq56a3RM+vF0jL9fyP2GNMAqyDxR0kty+zXxE4lSh2CxwzEVL5ltTbSkBGezhO978okG1jgPfupNxZw9MYg==",
       "requires": {
-        "chromedriver": "^83.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^8.1.0",
-        "http-server": "^0.11.1",
+        "chromedriver": "^87.0.5",
+        "execa": "^4.0.3",
+        "fs-extra": "^9.0.1",
+        "http-server": "^0.12.3",
         "nightwatch": "^1.2.4",
+        "uint8arrays": "^1.1.0",
         "which": "^2.0.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "http-server": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
-          "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
-          "requires": {
-            "colors": "1.0.3",
-            "corser": "~2.0.0",
-            "ecstatic": "^3.0.0",
-            "http-proxy": "^1.8.1",
-            "opener": "~1.4.0",
-            "optimist": "0.6.x",
-            "portfinder": "^1.0.13",
-            "union": "~0.4.3"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-        }
       }
     },
     "through": {
@@ -10150,18 +10148,6 @@
       "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
       "integrity": "sha1-jru/1tYpXxNwAD+7NxYq/loKUdE="
     },
-    "tiny-secp256k1": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
-      "requires": {
-        "bindings": "^1.3.0",
-        "bn.js": "^4.11.8",
-        "create-hmac": "^1.1.7",
-        "elliptic": "^6.4.0",
-        "nan": "^2.13.2"
-      }
-    },
     "to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
@@ -10212,9 +10198,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tty-browserify": {
       "version": "0.0.1",
@@ -10266,11 +10252,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typeforce": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
-    },
     "typical": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-6.0.1.tgz",
@@ -10305,12 +10286,17 @@
       }
     },
     "union": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
-      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
       "requires": {
-        "qs": "~2.3.3"
+        "qs": "^6.4.0"
       }
+    },
+    "unique-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
+      "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0="
     },
     "unique-string": {
       "version": "2.0.0",
@@ -10331,47 +10317,24 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "update-notifier": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.1.tgz",
-      "integrity": "sha512-9y+Kds0+LoLG6yN802wVXoIfxYEwh3FlZwzMwpCZp62S2i1/Jzeqb9Eeeju3NSHccGGasfGlK5/vEHbAifYRDg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.0.1.tgz",
+      "integrity": "sha512-BuVpRdlwxeIOvmc32AGYvO1KVdPlsmqSh8KDDBxS6kDE5VR7R8OMP1d8MdhaVBvxl4H3551k9akXr0Y1iIB2Wg==",
       "requires": {
         "boxen": "^4.2.0",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.0",
         "configstore": "^5.0.1",
         "has-yarn": "^2.1.0",
         "import-lazy": "^2.1.0",
         "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.3.1",
-        "is-npm": "^4.0.0",
+        "is-installed-globally": "^0.3.2",
+        "is-npm": "^5.0.0",
         "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "pupa": "^2.0.1",
+        "latest-version": "^5.1.0",
+        "pupa": "^2.1.1",
+        "semver": "^7.3.2",
         "semver-diff": "^3.1.1",
         "xdg-basedir": "^4.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "uri-js": {
@@ -10423,12 +10386,12 @@
       }
     },
     "ursa-optional": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.1.tgz",
-      "integrity": "sha512-/pgpBXVJut57dHNrdGF+1/qXi+5B7JrlmZDWPSyoivEcbwFWRZJBJGkWb6ivknMBA3bnFA7lqsb6iHiFfp79QQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.2.tgz",
+      "integrity": "sha512-TKdwuLboBn7M34RcvVTuQyhvrA8gYKapuVdm0nBP0mnBc7oECOfUQZrY91cefL3/nm64ZyrejSRrhTVdX7NG/A==",
       "requires": {
         "bindings": "^1.5.0",
-        "nan": "^2.14.0"
+        "nan": "^2.14.2"
       }
     },
     "utf8-byte-length": {
@@ -10464,9 +10427,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "varint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "varint-decoder": {
       "version": "1.0.0",
@@ -10474,14 +10437,13 @@
       "integrity": "sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==",
       "requires": {
         "varint": "^5.0.0"
-      }
-    },
-    "varuint-bitcoin": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
-      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
-      "requires": {
-        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
       }
     },
     "verror": {
@@ -10509,18 +10471,9 @@
       }
     },
     "web-encoding": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
-      "integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
-    },
-    "webcrypto": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/webcrypto/-/webcrypto-0.1.1.tgz",
-      "integrity": "sha512-BAvoatS38TbHdyt42ECLroi27NmDh5iea5l5rHC6nZTZjlbJlndrT0FoIiEq7fmPHpmNtP0lMFKVMEKZQFIrGA==",
-      "requires": {
-        "crypto-browserify": "^3.10.0",
-        "detect-node": "^2.0.3"
-      }
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.6.tgz",
+      "integrity": "sha512-26wEnRPEFAc5d5lmH1Q/DuvWEYsRF1D2alX2jlKpdmqv7cj+BbANL7Xlcl9r4s72Eg9kItZa9RWVbBMC9dMv4w=="
     },
     "webidl-conversions": {
       "version": "4.0.2",
@@ -10586,23 +10539,10 @@
         "string-width": "^4.0.0"
       }
     },
-    "wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-      "requires": {
-        "bs58check": "<3.0.0"
-      }
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "6.2.0",
@@ -10640,9 +10580,9 @@
       }
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
     },
     "xdg-basedir": {
       "version": "4.0.0",
@@ -10650,11 +10590,11 @@
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
     },
     "xhr": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
-      "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
       "requires": {
-        "global": "~4.3.0",
+        "global": "~4.4.0",
         "is-function": "^1.0.1",
         "parse-headers": "^2.0.0",
         "xtend": "^4.0.0"
@@ -10686,9 +10626,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -10696,21 +10636,49 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "requires": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+        }
       }
     },
     "yargs-parser": {
@@ -10721,11 +10689,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "yargs-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-promise/-/yargs-promise-1.1.0.tgz",
-      "integrity": "sha1-l+u1GY33NLs7EXRRM65bUBsWqx8="
     },
     "yargs-unparser": {
       "version": "1.6.0",
@@ -10882,14 +10845,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-    },
-    "zcash-block": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/zcash-block/-/zcash-block-2.0.0.tgz",
-      "integrity": "sha512-I6pv5b+eGE8CJFmltR+ILHnGcnBO8olV78VicQIaWulMhkomlwDmaMeMshJRLPcnd0FBs58QQVcVNBOT9ojH6Q==",
-      "requires": {
-        "multihashing": "~0.3.3"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,13 @@
     "uint8arrays": "^1.1.0"
   },
   "dependencies": {
-    "ipfs": "^0.50.1",
+    "ipfs": "^0.52.3",
     "it-all": "^1.0.1",
-    "libp2p-webrtc-direct": "^0.4.0",
+    "libp2p": "^0.30.0",
+    "libp2p-bootstrap": "^0.12.1",
+    "libp2p-mplex": "^0.10.1",
+    "libp2p-noise": "^2.0.1",
+    "libp2p-webrtc-direct": "libp2p/js-libp2p-webrtc-direct#fix/add-remote-addr-on-listener-connection",
     "test-ipfs-example": "^2.0.3"
   },
   "browser": {

--- a/public/browser-ipfs.js
+++ b/public/browser-ipfs.js
@@ -5,7 +5,7 @@ const Mplex = require('libp2p-mplex')
 const {NOISE} = require('libp2p-noise')
 const Bootstrap = require('libp2p-bootstrap')
 
-const createLibp2p = (opts, bootstrappers) => {
+const libp2pBundle = (opts) => {
   const peerId = opts.peerId
 
   return new Libp2p({
@@ -20,7 +20,7 @@ const createLibp2p = (opts, bootstrappers) => {
       peerDiscovery: {
         [Bootstrap.tag]: {
           enabled: true,
-          list: ['/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct/p2p/QmRs9AvhnGUSw2mEFR39Z7UAxnX8wXMo1y8vUSZJwtSfSn']
+          list: ['/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct/p2p/QmPj9ZZ6notLfV9khV1FtxH1Goe5sVaUyqgoXrTYQWp382']
         }
       }
     }
@@ -31,7 +31,7 @@ const createLibp2p = (opts, bootstrappers) => {
 async function main () {
   const node = await IPFS.create({
     repo: 'ipfs-' + Math.random(),
-    lib2p: createLibp2p,
+    libp2p: libp2pBundle
     // How to correctly set bootstrappers?
     // libp2p: (...args) => createLibp2p(...args, ['/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct/p2p/QmYdb3fr52UxH6evf9UnKY8YvvRrnskt9ULKuS2n69THz9']),
     // Bootstrap: ['/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct/p2p/QmYdb3fr52UxH6evf9UnKY8YvvRrnskt9ULKuS2n69THz9']


### PR DESCRIPTION
@vogdb per https://github.com/libp2p/js-libp2p-webrtc-direct/issues/94 I created this PR to fix the remaining issues. Note that I also updated the dependencies.

Firstly, I added the libp2p dependencies as this module dependency. While these dependencies were already in the `node_modules` as they are installed by IPFS default bundle, they should be included here as IPFS can change what dependencies it uses.

The main bug here was `libp2p` key in the configuration incorrectly spelled. Testing this I found 2 issues that needed to be addresses to have this properly working:

- [ ] https://github.com/libp2p/js-libp2p-webrtc-direct/pull/97
- [ ] https://github.com/multiformats/js-mafmt/pull/71

I am installing webrtc-direct commit directly for now, until that gets merged + released. If you want to test this out, I recommend that you manually comment https://github.com/libp2p/js-libp2p-bootstrap/blob/master/src/index.js#L56-L58 in your node_modules while the `mafmt` PR gets merged + released